### PR TITLE
Tweak POST to use pure POST api

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -87,7 +87,7 @@ module Coverage
 
         # Try Keno's hack
         files = {JSON.json(data)}
-        r = Requests.post(URI("https://coveralls.io/api/v1/jobs"),join([string("--someuniquestring\nContent-Type: text/json\n\n",filetext) for filetext in files],""),["Content-Type"=>"multipart/mixed; boundary=someuniquestring"])
+        r = Requests.post(URI("https://coveralls.io/api/v1/jobs"), data={"json" => JSON.json(data)}, headers={"Content-Type"=>"text/form-data"})
         println(r.data)
     end
 


### PR DESCRIPTION
Instead of multipart nonsense, use the [undocumented form-data POST API](https://github.com/lemurheavy/coveralls-public/issues/16) (I got the idea from [this guy](https://github.com/cainus/node-coveralls/blob/master/lib/sendToCoveralls.js))

Note that I haven't tested this, since I'm not sure how to run this Coverage.jl thing, but in a REPL session, the following returned me something:

``` julia
julia> data
{"source_files"=>[{"coverage"=>{nothing,1,nothing},"name"=>"example.rb","source"=>"def four\
n  4\nend"},{"coverage"=>{nothing,1,0,nothing},"name"=>"lib/two.rb","source"=>"def seven\n  
eight\n  nine\nend"}],"repo_token"=>"NnS70s2bP8Wwvxquax6rdRz4zDnEwW5OK"}

julia> r = Requests.post(URI("https://coveralls.io/api/v1/jobs"), data = {"json" => json(dat
a)}, headers={"Content-Type" => "text/form-data"})
<snip a bunch of deprecation warnings>
Response(200 OK, 20 Headers, 66 Bytes in Body)

julia> r.data
"{\"message\":\"Job #3.1\",\"url\":\"https://coveralls.io/jobs/1754807\"}\r\n"
```
