### PR TITLE
Mechanism for excluding files and lines.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ JSON
 Requests
 JuliaParser
 Compat
+YAML


### PR DESCRIPTION
This addresses #44 and #53. It allows a per-directory file called '.coverage.yml' that looks like

``` yaml
# exclude files in the directory with these names
exclude_files:
  - foo.jl
  - bar.jl

# exclude any lines that match any of the following regexes
exclude_patterns:
  - "\[NO COVERAGE\]"
```
