### PR TITLE
Generic codecov submissions to support enterprise installations

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -105,7 +105,6 @@ module Codecov
     @deprecate submit_token submit_local
 
 
-
     """
         submit_generic(fcs::Vector{FileCoverage})
 

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -48,7 +48,7 @@ module Codecov
     function set_defaults(args_array; kwargs...)
         defined_names = [k for (k,v) in args_array]
         for kwarg in kwargs
-            if ~(kwarg[1] in defined_names)
+            if !(kwarg[1] in defined_names)
                 push!(args_array, kwarg)
             end
         end
@@ -81,13 +81,17 @@ module Codecov
     """
         submit_token(fcs::Vector{FileCoverage})
 
-    make depreciated
+    Takes a `Vector` of file coverage results (produced by `process_folder`),
+    and submits them to Codecov.io. Assumes the submission is being made from 
+    a local git installation.  A repository token should be specified by a 
+    'token' keyword argument or the CODECOV_TOKEN environment variable.
     """
-    function submit_token(fcs::Vector{FileCoverage})
+    function submit_token(fcs::Vector{FileCoverage}; kwargs...)
         println("submit_token is deprecated, use submit_local instead")
-        submit_local(fcs)
+        submit_local(fcs; kwargs...)
     end
 
+    @deprecate submit_token submit_local
 
     import Base.Git
 
@@ -170,3 +174,4 @@ module Codecov
     end
 
 end  # module Codecov
+

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -114,7 +114,7 @@ module Codecov
     values match the Codecov upload/v2 API specification.  
     The `codecov_url` keyword argument or the CODECOV_URL environment variable 
     can be used to specify the base path of the uri.
-    The `julia_test` keyword can be used to prevent the http request from 
+    The `dry_run` keyword can be used to prevent the http request from 
     being generated
     """
     function submit_generic(fcs::Vector{FileCoverage}; kwargs...)
@@ -129,20 +129,20 @@ module Codecov
         end
 
         codecov_url = "https://codecov.io"
-        julia_test = false
+        dry_run = false
         for (k,v) in kwargs
             if k == :codecov_url
                 codecov_url = v
             end
-            if k == :julia_test
-                julia_test = true
+            if k == :dry_run
+                dry_run = true
             end
         end
         @assert codecov_url[end] != "/" "the codecov_url should not end with a /, given url $(codecov_url)"
 
         uri_str = "$(codecov_url)/upload/v2?"
         for (k,v) in kwargs
-            if k != :codecov_url && k != :julia_test
+            if k != :codecov_url && k != :dry_run
                 uri_str = "$(uri_str)&$(k)=$(v)"
             end
         end
@@ -150,7 +150,7 @@ module Codecov
         println("Codecov.io API URL:")
         println(uri_str)
 
-        if !julia_test
+        if !dry_run
             heads   = Dict("Content-Type" => "application/json")
             data    = to_json(fcs)
             req     = Requests.post(URI(uri_str); json = data, headers = heads)

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -65,7 +65,6 @@ module Codecov
     """
     function submit(fcs::Vector{FileCoverage}; kwargs...)
         kwargs = set_defaults(kwargs, 
-            codecov_url = "https://codecov.io",
             service      = "travis-org",
             branch       = ENV["TRAVIS_BRANCH"],
             commit       = ENV["TRAVIS_COMMIT"],
@@ -102,7 +101,6 @@ module Codecov
     """
     function submit_local(fcs::Vector{FileCoverage}; kwargs...)
         kwargs = set_defaults(kwargs, 
-            codecov_url = "https://codecov.io",
             commit = Git.readchomp(`rev-parse HEAD`, dir=""), 
             branch = Git.branch(dir="")
             )
@@ -140,7 +138,7 @@ module Codecov
             kwargs = set_defaults(kwargs, token = ENV["CODECOV_TOKEN"])
         end
 
-        codecov_url = "None"
+        codecov_url = "https://codecov.io"
         julia_test = false
         for (k,v) in kwargs
             if k == :codecov_url
@@ -150,8 +148,7 @@ module Codecov
                 julia_test = true
             end
         end
-        @assert codecov_url != "None"
-        @assert codecov_url[end] != "/"
+        @assert codecov_url[end] != "/" "the codecov_url should not end with a /, given url $(codecov_url)"
 
         uri_str = "$(codecov_url)/upload/v2?"
         for (k,v) in kwargs

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -78,21 +78,6 @@ module Codecov
     end
 
 
-    """
-        submit_token(fcs::Vector{FileCoverage})
-
-    Takes a `Vector` of file coverage results (produced by `process_folder`),
-    and submits them to Codecov.io. Assumes the submission is being made from 
-    a local git installation.  A repository token should be specified by a 
-    'token' keyword argument or the CODECOV_TOKEN environment variable.
-    """
-    function submit_token(fcs::Vector{FileCoverage}; kwargs...)
-        println("submit_token is deprecated, use submit_local instead")
-        submit_local(fcs; kwargs...)
-    end
-
-    @deprecate submit_token submit_local
-
     import Base.Git
 
     """
@@ -116,6 +101,8 @@ module Codecov
 
         submit_generic(fcs; kwargs...)
     end
+
+    @deprecate submit_token submit_local
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,7 @@ fcs = FileCoverage[]
 # test local submission process
 
 # default values
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
 @test contains(codecov_url, "codecov.io")
 @test contains(codecov_url, "commit")
 @test contains(codecov_url, "branch")
@@ -141,14 +141,14 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_token(fcs) )
 
 # env var url override
 ENV["CODECOV_URL"] = "https://enterprise-codecov-1.com"
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
 @test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "commit")
 @test contains(codecov_url, "branch")
 @test !contains(codecov_url, "service")
 
 # function argument url override
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true, codecov_url = "https://enterprise-codecov-2.com") )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true, codecov_url = "https://enterprise-codecov-2.com") )
 @test contains(codecov_url, "enterprise-codecov-2.com")
 @test contains(codecov_url, "commit")
 @test contains(codecov_url, "branch")
@@ -156,13 +156,13 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; juli
 
 # env var token
 ENV["CODECOV_TOKEN"] = "token_name_1"
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
 @test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_1")
 @test !contains(codecov_url, "service")
 
 # function argument token
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true, token="token_name_2") )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true, token="token_name_2") )
 @test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_2")
 @test !contains(codecov_url, "service")
@@ -183,7 +183,7 @@ ENV["TRAVIS_REPO_SLUG"] = "t_slug"
 ENV["TRAVIS_JOB_NUMBER"] = "t_job_num"
 
 # default values
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
 @test contains(codecov_url, "codecov.io")
 @test contains(codecov_url, "service=travis-org")
 @test contains(codecov_url, "branch=t_branch")
@@ -195,7 +195,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 
 # env var url override
 ENV["CODECOV_URL"] = "https://enterprise-codecov-1.com"
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
 @test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "service=travis-org")
 @test contains(codecov_url, "branch=t_branch")
@@ -206,7 +206,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 @test contains(codecov_url, "build=t_job_num")
 
 # function argument url override
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true, codecov_url = "https://enterprise-codecov-2.com") )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true, codecov_url = "https://enterprise-codecov-2.com") )
 @test contains(codecov_url, "enterprise-codecov-2.com")
 @test contains(codecov_url, "service=travis-org")
 @test contains(codecov_url, "branch=t_branch")
@@ -218,7 +218,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 
 # env var token
 ENV["CODECOV_TOKEN"] = "token_name_1"
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
 @test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_1")
 @test contains(codecov_url, "branch=t_branch")
@@ -229,7 +229,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 @test contains(codecov_url, "build=t_job_num")
 
 # function argument token
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true, token="token_name_2") )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true, token="token_name_2") )
 @test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_2")
 @test contains(codecov_url, "branch=t_branch")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,13 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; juli
 @test contains(codecov_url, "branch")
 @test !contains(codecov_url, "service")
 
+# default values in depreciated call
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_token(fcs; julia_test = true) )
+@test contains(codecov_url, "codecov.io")
+@test contains(codecov_url, "commit")
+@test contains(codecov_url, "branch")
+@test !contains(codecov_url, "service")
+
 # env var url override
 ENV["CODECOV_URL"] = "https://enterprise-codecov-1.com"
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true) )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,7 +133,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; juli
 @test !contains(codecov_url, "service")
 
 # default values in depreciated call
-codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_token(fcs; julia_test = true) )
+codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_token(fcs) )
 @test contains(codecov_url, "codecov.io")
 @test contains(codecov_url, "commit")
 @test contains(codecov_url, "branch")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,6 @@ using Coverage, Base.Test
 @test Coverage.iscovfile("/somedir/test.jl.8392.cov", "/somedir/test.jl")
 @test !Coverage.iscovfile("/otherdir/test.jl.cov", "/somedir/test.jl")
 
-if false
 cd(Pkg.dir("Coverage")) do
     datadir = joinpath("test", "data")
     # Process a saved set of coverage data...
@@ -61,7 +60,6 @@ cd(Pkg.dir("Coverage")) do
     open("fakefile",true,true,true,false,false)
     @test isempty(Coverage.process_cov("fakefile",datadir))
     rm("fakefile")
-end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ using Coverage, Base.Test
 @test Coverage.iscovfile("/somedir/test.jl.8392.cov", "/somedir/test.jl")
 @test !Coverage.iscovfile("/otherdir/test.jl.cov", "/somedir/test.jl")
 
-
+if false
 cd(Pkg.dir("Coverage")) do
     datadir = joinpath("test", "data")
     # Process a saved set of coverage data...
@@ -62,7 +62,7 @@ cd(Pkg.dir("Coverage")) do
     @test isempty(Coverage.process_cov("fakefile",datadir))
     rm("fakefile")
 end
-
+end
 
 
 
@@ -137,7 +137,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; juli
 # env var url override
 ENV["CODECOV_URL"] = "https://enterprise-codecov-1.com"
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true) )
-#@test contains(codecov_url, "enterprise-codecov-1.com")
+@test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "commit")
 @test contains(codecov_url, "branch")
 @test !contains(codecov_url, "service")
@@ -152,13 +152,13 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; juli
 # env var token
 ENV["CODECOV_TOKEN"] = "token_name_1"
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true) )
-#@test contains(codecov_url, "enterprise-codecov-1.com")
+@test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_1")
 @test !contains(codecov_url, "service")
 
 # function argument token
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; julia_test = true, token="token_name_2") )
-#@test contains(codecov_url, "enterprise-codecov-1.com")
+@test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_2")
 @test !contains(codecov_url, "service")
 
@@ -191,7 +191,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 # env var url override
 ENV["CODECOV_URL"] = "https://enterprise-codecov-1.com"
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true) )
-#@test contains(codecov_url, "enterprise-codecov-1.com")
+@test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "service=travis-org")
 @test contains(codecov_url, "branch=t_branch")
 @test contains(codecov_url, "commit=t_commit")
@@ -214,7 +214,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 # env var token
 ENV["CODECOV_TOKEN"] = "token_name_1"
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true) )
-#@test contains(codecov_url, "enterprise-codecov-1.com")
+@test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_1")
 @test contains(codecov_url, "branch=t_branch")
 @test contains(codecov_url, "commit=t_commit")
@@ -225,7 +225,7 @@ codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test
 
 # function argument token
 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; julia_test = true, token="token_name_2") )
-#@test contains(codecov_url, "enterprise-codecov-1.com")
+@test contains(codecov_url, "enterprise-codecov-1.com")
 @test contains(codecov_url, "token=token_name_2")
 @test contains(codecov_url, "branch=t_branch")
 @test contains(codecov_url, "commit=t_commit")


### PR DESCRIPTION
I am fairly new to Julia so I might have done this all wrong, please don't hesitate to tell me so.  :-)

I ran into a problem with the current Codecov implementation where I could not submit reports to an enterprise installation of Codecov.  The key problem was that the uri needs to point to something like "enterprise-codecov.com" instead of "codecov.io", and even if I am using Travis-CI I need to provide a repo token.

Summary of the proposed changes:
- adding a new generic submission method (i.e. `generic_submit`)
- re-casting existing submission methods in terms of `generic_submit`
- deprecating `submit_token` in favor of a hopefully more intuitive name `submit_local`
- making environment variables consistent with [codecov-bash](https://github.com/codecov/codecov-bash) 
- deprecating `REPO_TOKEN` in favor of `CODECOV_TOKEN` used by codecov-bash

The approach:
To fix my enterprise codecov issues, and hopefully guard against similar issues in the future, I took the approach of making a generic_submit function, which builds the codecov uri from the function's keyword arguments.  Hence, the upload uri can be adapted or extended easily by passing new keyword arguments this function.

With the new generic_submit, we can now see submit and submit_token as simply defining some default values to pass to generic_submit.  Any of these default values can be overridden simply by passing the appropriate keyword argument to those functions.  When no default value or keyword argument are specified, environment variables are checked and used if available.

I have verified this works on enterprise use cases, but have not tested the non-enterprise uses cases.