### PR TITLE
Prepare for upcoming deletion of Base.Git module

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 JSON
 Requests
+Git

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -78,7 +78,7 @@ module Codecov
     end
 
 
-    import Base.Git
+    import Git
 
     """
         submit_local(fcs::Vector{FileCoverage})

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -63,7 +63,7 @@ module Coveralls
     # query_git_info
     # Pulls information about the repository that isn't available if we
     # are running somewhere other than TravisCI
-    import Base.Git
+    import Git
     function query_git_info(dir="")
         commit_sha      = Git.readchomp(`rev-parse HEAD`, dir=dir)
         author_name     = Git.readchomp(`log -1 --pretty=format:"%aN"`, dir=dir)


### PR DESCRIPTION
(to whom it may concern...)

https://github.com/JuliaPackaging/Git.jl should be essentially equivalent, but will also ensure that you have git installed on platforms where it knows how to get a binary. If you already have git on your system path it'll just use it.