### PR TITLE
isdefined->isassigned

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -73,8 +73,8 @@ module Coverage
         n = max(length(a1),length(a2))
         a = Array(CovCount, n)
         for i in 1:n
-            a1v = isdefined(a1, i) ? a1[i] : nothing
-            a2v = isdefined(a2, i) ? a2[i] : nothing
+            a1v = isassigned(a1, i) ? a1[i] : nothing
+            a2v = isassigned(a2, i) ? a2[i] : nothing
             a[i] = a1v == nothing ? a2v :
                    a2v == nothing ? a1v : max(a1v, a2v)
         end


### PR DESCRIPTION
`isdefined(a, 5)` is deprecated in 0.6-dev, and changing it to `isassigned` works even on julia-0.4. Needed to avoid insanely-long travis builds (https://travis-ci.org/JuliaLang/DataStructures.jl/builds/158928733).
