### PR TITLE
Submit coverage reports from AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,17 @@ When using Coverage.jl locally, over time a lot of `.cov` files can accumulate. 
 2. Use the command line option when you run your tests
   * Either with something like `julia --code-coverage test/runtests.jl`, or
   * with something like  `julia -e 'Pkg.test("MyPkg", coverage=true)'`
-3. Add the following to the end of your `.travis.yml` file. This line downloads this package, collects the per-file coverage data, then bundles it up and submits to Codecov. Coverage.jl assumes that the working directory is the package directory, so it changes to that first (so don't forget to replace `MyPkg` with your package's name!
-```yml
-after_success:
-- julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-```
+3. Add the following to the end of your `.travis.yml` or `.appveyor.yml` file. This line downloads this package, collects the per-file coverage data, then bundles it up and submits to Codecov. Coverage.jl assumes that the working directory is the package directory, so it changes to that first (so don't forget to replace `MyPkg` with your package's name!
+  * On Travis CI:
+  ```yml
+  after_success:
+  - julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  ```
+  * On AppVeyor:
+  ```yml
+  after_test:
+  - C:\projects\julia\bin\julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  ```
 If you're running coverage on your own machine and want to upload results to Codecov, make a bash script like the following:
 ```bash
 #!/bin/bash
@@ -114,11 +120,17 @@ REPO_TOKEN=$YOUR_TOKEN_HERE julia -e 'cd(Pkg.dir("MyPkg")); using Coverage; Code
 3. Use the command line option when you run your tests
   * Either with something like `julia --code-coverage test/runtests.jl`, or
   * with something like  `julia -e 'Pkg.test("MyPkg", coverage=true)'`
-4. Add the following to the end of your `.travis.yml` or `appveyor.yml` file. This line downloads this package, collects the per-file coverage data, then bundles it up and submits to Coveralls. Coverage.jl assumes that the working directory is the package directory, so it changes to that first (so don't forget to replace `MyPkg` with your package's name!
-```yml
-after_success:
-- julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
-```
+4. Add the following to the end of your `.travis.yml` or `.appveyor.yml` file. This line downloads this package, collects the per-file coverage data, then bundles it up and submits to Coveralls. Coverage.jl assumes that the working directory is the package directory, so it changes to that first (so don't forget to replace `MyPkg` with your package's name!
+  * On Travis CI:
+  ```yml
+  after_success:
+  - julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  ```
+  * On AppVeyor:
+  ```yml
+  after_test:
+  - C:\projects\julia\bin\julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  ```
 
 
 ## Julia packages using Coverage.jl

--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ REPO_TOKEN=$YOUR_TOKEN_HERE julia -e 'cd(Pkg.dir("MyPkg")); using Coverage; Code
 
 [Coveralls.io](https://coveralls.io) is a test coverage tracking tool that integrates with your continuous integration solution (e.g. [TravisCI](https://travis-ci.org/)).
 
-1. Enable [Coveralls.io](https://coveralls.io) for your repository. If it is public on GitHub and you are using TravisCI, this is all you need to do. If this isn't the case, please submit an issue, and we can work on adding additional functionality for your use case.
+1. Enable [Coveralls.io](https://coveralls.io) for your repository. If it is public on GitHub and you are using TravisCI, this is all you need to do. If you are using AppVeyor, you need to add a secure environment variable called `REPO_TOKEN` to your `.appveyor.yml` (see [here](https://www.appveyor.com/docs/build-configuration/#secure-variables)). Your repo token can be found in your Coveralls repo settings. If neither of these are true, please submit an issue, and we can work on adding additional functionality for your use case.
 2. You must be using `Julia 0.3` or higher, which added the `--code-coverage` command line argument.
 3. Use the command line option when you run your tests
   * Either with something like `julia --code-coverage test/runtests.jl`, or
   * with something like  `julia -e 'Pkg.test("MyPkg", coverage=true)'`
-4. Add the following to the end of your `.travis.yml` file. This line downloads this package, collects the per-file coverage data, then bundles it up and submits to Coveralls. Coverage.jl assumes that the working directory is the package directory, so it changes to that first (so don't forget to replace `MyPkg` with your package's name!
+4. Add the following to the end of your `.travis.yml` or `appveyor.yml` file. This line downloads this package, collects the per-file coverage data, then bundles it up and submits to Coveralls. Coverage.jl assumes that the working directory is the package directory, so it changes to that first (so don't forget to replace `MyPkg` with your package's name!
 ```yml
 after_success:
 - julia -e 'cd(Pkg.dir("MyPkg")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -65,9 +65,8 @@ module Codecov
     on TravisCI or AppVeyor. If running locally, use `submit_local`.
     """
     function submit(fcs::Vector{FileCoverage}; kwargs...)
-        if haskey(ENV, "APPVEYOR") && lowercase(ENV["APPVEYOR"]) == "true"
-            appveyor_pr = haskey(ENV, "APPVEYOR_PULL_REQUEST_NUMBER") ?
-                ENV["APPVEYOR_PULL_REQUEST_NUMBER"] : ""
+        if lowercase(get(ENV, "APPVEYOR", "false")) == "true"
+            appveyor_pr = get(ENV, "APPVEYOR_PULL_REQUEST_NUMBER", "")
             appveyor_job = join(
                 [
                     ENV["APPVEYOR_ACCOUNT_NAME"],
@@ -85,7 +84,7 @@ module Codecov
                 slug         = ENV["APPVEYOR_REPO_NAME"],
                 build        = ENV["APPVEYOR_JOB_ID"],
             )
-        elseif haskey(ENV, "TRAVIS_CI") && lowercase(ENV["TRAVIS_CI"]) == "true"
+        elseif lowercase(get(ENV, "TRAVIS", "false")) == "true"
             kwargs = set_defaults(kwargs,
                 service      = "travis-org",
                 branch       = ENV["TRAVIS_BRANCH"],

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -65,7 +65,7 @@ module Codecov
     on TravisCI or AppVeyor. If running locally, use `submit_local`.
     """
     function submit(fcs::Vector{FileCoverage}; kwargs...)
-        if ENV["APPVEYOR"] == "True"
+        if haskey(ENV, "APPVEYOR") && ENV["APPVEYOR"] == "True"
             appveyor_pr = haskey(ENV, "APPVEYOR_PULL_REQUEST_NUMBER") ?
                 ENV["APPVEYOR_PULL_REQUEST_NUMBER"] : ""
             appveyor_job = join(
@@ -85,7 +85,7 @@ module Codecov
                 slug         = ENV["APPVEYOR_REPO_NAME"],
                 build        = ENV["APPVEYOR_JOB_ID"],
             )
-        elseif ENV["TRAVIS_CI"] == "True"
+        elseif haskey(ENV, "TRAVIS_CI") && ENV["TRAVIS_CI"] == "True"
             kwargs = set_defaults(kwargs,
                 service      = "travis-org",
                 branch       = ENV["TRAVIS_BRANCH"],

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -65,7 +65,7 @@ module Codecov
     on TravisCI or AppVeyor. If running locally, use `submit_local`.
     """
     function submit(fcs::Vector{FileCoverage}; kwargs...)
-        if haskey(ENV, "APPVEYOR") && ENV["APPVEYOR"] == "True"
+        if haskey(ENV, "APPVEYOR") && lowercase(ENV["APPVEYOR"]) == "true"
             appveyor_pr = haskey(ENV, "APPVEYOR_PULL_REQUEST_NUMBER") ?
                 ENV["APPVEYOR_PULL_REQUEST_NUMBER"] : ""
             appveyor_job = join(
@@ -85,7 +85,7 @@ module Codecov
                 slug         = ENV["APPVEYOR_REPO_NAME"],
                 build        = ENV["APPVEYOR_JOB_ID"],
             )
-        elseif haskey(ENV, "TRAVIS_CI") && ENV["TRAVIS_CI"] == "True"
+        elseif haskey(ENV, "TRAVIS_CI") && lowercase(ENV["TRAVIS_CI"]) == "true"
             kwargs = set_defaults(kwargs,
                 service      = "travis-org",
                 branch       = ENV["TRAVIS_BRANCH"],

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -50,7 +50,7 @@ module Coveralls
     on TravisCI or AppVeyor. If running locally, use `submit_token`.
     """
     function submit(fcs::Vector{FileCoverage})
-        if haskey(ENV, "APPVEYOR") && lowercase(ENV["APPVEYOR"]) == "true"
+        if lowercase(get(ENV, "APPVEYOR", "false")) == "true"
             # Submission from AppVeyor requires a REPO_TOKEN environment variable
             data = Dict("service_job_id"    => ENV["APPVEYOR_JOB_ID"],
                         "service_name"      => "appveyor",
@@ -63,7 +63,7 @@ module Coveralls
             println("Result of submission:")
             println(Compat.UTF8String(req.data))
 
-        elseif haskey(ENV, "TRAVIS_CI") && lowercase(ENV["TRAVIS_CI"]) == "true"
+        elseif lowercase(get(ENV, "TRAVIS", "false")) == "true"
             data = Dict("service_job_id"    => ENV["TRAVIS_JOB_ID"],
                         "service_name"      => "travis-ci",
                         "source_files"      => map(to_json, fcs))

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -47,18 +47,35 @@ module Coveralls
 
     Take a vector of file coverage results (produced by `process_folder`),
     and submits them to Coveralls. Assumes that this code is being run
-    on TravisCI. If running locally, use `submit_token`.
+    on TravisCI or AppVeyor. If running locally, use `submit_token`.
     """
     function submit(fcs::Vector{FileCoverage})
-        data = Dict("service_job_id"    => ENV["TRAVIS_JOB_ID"],
-                    "service_name"      => "travis-ci",
-                    "source_files"      => map(to_json, fcs))
-        println("Submitting data to Coveralls...")
-        req = Requests.post(
+        if haskey(ENV, "APPVEYOR") && lowercase(ENV["APPVEYOR"]) == "true"
+            # Submission from AppVeyor requires a REPO_TOKEN environment variable
+            data = Dict("service_job_id"    => ENV["APPVEYOR_JOB_ID"],
+                        "service_name"      => "appveyor",
+                        "source_files"      => map(to_json, fcs),
+                        "repo_token"        => ENV["REPO_TOKEN"])
+            println("Submitting data to Coveralls...")
+            req = Requests.post(
                 URI("https://coveralls.io/api/v1/jobs"),
                 files = [FileParam(JSON.json(data),"application/json","json_file","coverage.json")])
-        println("Result of submission:")
-        println(Compat.UTF8String(req.data))
+            println("Result of submission:")
+            println(Compat.UTF8String(req.data))
+
+        elseif haskey(ENV, "TRAVIS_CI") && lowercase(ENV["TRAVIS_CI"]) == "true"
+            data = Dict("service_job_id"    => ENV["TRAVIS_JOB_ID"],
+                        "service_name"      => "travis-ci",
+                        "source_files"      => map(to_json, fcs))
+            println("Submitting data to Coveralls...")
+            req = Requests.post(
+                URI("https://coveralls.io/api/v1/jobs"),
+                files = [FileParam(JSON.json(data),"application/json","json_file","coverage.json")])
+            println("Result of submission:")
+            println(Compat.UTF8String(req.data))
+        else
+            error("No compatible CI platform detected")
+        end
     end
 
     # query_git_info

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,7 @@ withenv(
 
     # test local submission process
 
+
     # default values
     codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
     @test contains(codecov_url, "codecov.io")
@@ -181,6 +182,11 @@ withenv(
             @test !contains(codecov_url, "service")
         end
     end
+
+
+    # test faulty non-CI submission
+
+    @test_throws ErrorException extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
 
     # test travis-ci submission process
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,7 @@ function extract_codecov_url(fun)
         end
     end
 
-    #println("url: $(url)")
+    # println("url: $(url)")
     @assert url != "None" "unable to find codecov api url in stdout, check for changes in codecovio.jl"
     return url
 end
@@ -123,6 +123,15 @@ withenv(
     "TRAVIS_JOB_ID" => nothing,
     "TRAVIS_REPO_SLUG" => nothing,
     "TRAVIS_JOB_NUMBER" => nothing,
+    "APPVEYOR" => nothing,
+    "APPVEYOR_PULL_REQUEST_NUMBER" => nothing,
+    "APPVEYOR_ACCOUNT_NAME" => nothing,
+    "APPVEYOR_PROJECT_SLUG" => nothing,
+    "APPVEYOR_BUILD_VERSION" => nothing,
+    "APPVEYOR_REPO_BRANCH" => nothing,
+    "APPVEYOR_REPO_COMMIT" => nothing,
+    "APPVEYOR_REPO_NAME" => nothing,
+    "APPVEYOR_JOB_ID" => nothing,
     ) do
 
     # test local submission process
@@ -247,5 +256,77 @@ withenv(
             end
         end
     end
+
+    # test appveyor submission process
+
+    # set up appveyor env
+    withenv(
+        "APPVEYOR" => "True",
+        "APPVEYOR_PULL_REQUEST_NUMBER" => "t_pr",
+        "APPVEYOR_ACCOUNT_NAME" => "t_account",
+        "APPVEYOR_PROJECT_SLUG" => "t_slug",
+        "APPVEYOR_BUILD_VERSION" => "t_version",
+        "APPVEYOR_REPO_BRANCH" => "t_branch",
+        "APPVEYOR_REPO_COMMIT" => "t_commit",
+        "APPVEYOR_REPO_NAME" => "t_repo",
+        "APPVEYOR_JOB_ID" => "t_job_num",
+        ) do
+
+            # default values
+            codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
+            @test contains(codecov_url, "codecov.io")
+            @test contains(codecov_url, "service=appveyor")
+            @test contains(codecov_url, "branch=t_branch")
+            @test contains(codecov_url, "commit=t_commit")
+            @test contains(codecov_url, "pull_request=t_pr")
+            @test contains(codecov_url, "job=t_account%2Ft_slug%2Ft_version")
+            @test contains(codecov_url, "build=t_job_num")
+
+            # env var url override
+            withenv( "CODECOV_URL" => "https://enterprise-codecov-1.com" ) do
+
+                codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
+                @test contains(codecov_url, "enterprise-codecov-1.com")
+                @test contains(codecov_url, "service=appveyor")
+                @test contains(codecov_url, "branch=t_branch")
+                @test contains(codecov_url, "commit=t_commit")
+                @test contains(codecov_url, "pull_request=t_pr")
+                @test contains(codecov_url, "job=t_account%2Ft_slug%2Ft_version")
+                @test contains(codecov_url, "build=t_job_num")
+
+                # function argument url override
+                codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true, codecov_url = "https://enterprise-codecov-2.com") )
+                @test contains(codecov_url, "enterprise-codecov-2.com")
+                @test contains(codecov_url, "service=appveyor")
+                @test contains(codecov_url, "branch=t_branch")
+                @test contains(codecov_url, "commit=t_commit")
+                @test contains(codecov_url, "pull_request=t_pr")
+                @test contains(codecov_url, "job=t_account%2Ft_slug%2Ft_version")
+                @test contains(codecov_url, "build=t_job_num")
+
+                # env var token
+                withenv( "CODECOV_TOKEN" => "token_name_1" ) do
+
+                    codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
+                    @test contains(codecov_url, "enterprise-codecov-1.com")
+                    @test contains(codecov_url, "token=token_name_1")
+                    @test contains(codecov_url, "branch=t_branch")
+                    @test contains(codecov_url, "commit=t_commit")
+                    @test contains(codecov_url, "pull_request=t_pr")
+                    @test contains(codecov_url, "job=t_account%2Ft_slug%2Ft_version")
+                    @test contains(codecov_url, "build=t_job_num")
+
+                    # function argument token url override
+                    codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true, token="token_name_2") )
+                    @test contains(codecov_url, "enterprise-codecov-1.com")
+                    @test contains(codecov_url, "token=token_name_2")
+                    @test contains(codecov_url, "branch=t_branch")
+                    @test contains(codecov_url, "commit=t_commit")
+                    @test contains(codecov_url, "pull_request=t_pr")
+                    @test contains(codecov_url, "job=t_account%2Ft_slug%2Ft_version")
+                    @test contains(codecov_url, "build=t_job_num")
+                end
+            end
+        end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,7 +116,7 @@ fcs = FileCoverage[]
 withenv(
     "CODECOV_URL" => nothing,
     "CODECOV_TOKEN" => nothing,
-    "TRAVIS_CI" => nothing,
+    "TRAVIS" => nothing,
     "TRAVIS_BRANCH" => nothing,
     "TRAVIS_COMMIT" => nothing,
     "TRAVIS_PULL_REQUEST" => nothing,
@@ -186,7 +186,7 @@ withenv(
 
     # set up travis env
     withenv(
-        "TRAVIS_CI" => "true",
+        "TRAVIS" => "true",
         "TRAVIS_BRANCH" => "t_branch",
         "TRAVIS_COMMIT" => "t_commit",
         "TRAVIS_PULL_REQUEST" => "t_pr",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,16 +112,17 @@ end
 # empty file coverage for testing
 fcs = FileCoverage[]
 
-# setup base system ENV vars for testing
+# set up base system ENV vars for testing
 withenv(
     "CODECOV_URL" => nothing,
     "CODECOV_TOKEN" => nothing,
+    "TRAVIS_CI" => nothing,
     "TRAVIS_BRANCH" => nothing,
     "TRAVIS_COMMIT" => nothing,
     "TRAVIS_PULL_REQUEST" => nothing,
     "TRAVIS_JOB_ID" => nothing,
     "TRAVIS_REPO_SLUG" => nothing,
-    "TRAVIS_JOB_NUMBER" => nothing
+    "TRAVIS_JOB_NUMBER" => nothing,
     ) do
 
     # test local submission process
@@ -172,17 +173,17 @@ withenv(
         end
     end
 
-
     # test travis-ci submission process
 
-    #setup travis env
+    # set up travis env
     withenv(
+        "TRAVIS_CI" => "True",
         "TRAVIS_BRANCH" => "t_branch",
         "TRAVIS_COMMIT" => "t_commit",
         "TRAVIS_PULL_REQUEST" => "t_pr",
         "TRAVIS_JOB_ID" => "t_job_id",
         "TRAVIS_REPO_SLUG" => "t_slug",
-        "TRAVIS_JOB_NUMBER" => "t_job_num"
+        "TRAVIS_JOB_NUMBER" => "t_job_num",
         ) do
 
         # default values

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,7 +186,7 @@ withenv(
 
     # set up travis env
     withenv(
-        "TRAVIS_CI" => "True",
+        "TRAVIS_CI" => "true",
         "TRAVIS_BRANCH" => "t_branch",
         "TRAVIS_COMMIT" => "t_commit",
         "TRAVIS_PULL_REQUEST" => "t_pr",
@@ -261,7 +261,7 @@ withenv(
 
     # set up appveyor env
     withenv(
-        "APPVEYOR" => "True",
+        "APPVEYOR" => "true",
         "APPVEYOR_PULL_REQUEST_NUMBER" => "t_pr",
         "APPVEYOR_ACCOUNT_NAME" => "t_account",
         "APPVEYOR_PROJECT_SLUG" => "t_slug",


### PR DESCRIPTION
These changes let you push coverage reports to CodeCov from AppVeyor builds. However, for now this will only be useful for Julia versions <= 0.4 (see [here](https://github.com/JuliaLang/julia/issues/21289)).

Closes #124 