### PR TITLE
fix include bug, escape_string test filename

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ cd(dirname(@__DIR__)) do
     # clean out any previous coverage files. Don't use clean_folder because we
     # need to preserve the pre-baked coverage file Coverage.jl.cov
     clean_file(srcname)
-    cmdstr = "include(\"$srcname\"); using Base.Test; @test f2(2) == 4"
+    cmdstr = "include(\"$(escape_string(srcname))\"); using Base.Test; @test f2(2) == 4"
     run(`$JULIA_HOME/julia --code-coverage=user -e $cmdstr`)
     r = process_file(srcname, datadir)
     # The next one is the correct one, but julia & JuliaParser don't insert a line number after the 1-line @doc -> test


### PR DESCRIPTION
This line fails since it is not properly escaped  in windows where the  path delimiter is `\` 