### PR TITLE
Let programs using Coverage use command-line arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 JSON
 Requests
 Git

--- a/src/memalloc.jl
+++ b/src/memalloc.jl
@@ -56,7 +56,7 @@ isfuncexpr(ex::Expr) =
 isfuncexpr(arg) = false
 
 # Support Unix command line usage like `julia Coverage.jl $(find ~/.julia/v0.6 -name "*.jl.mem")`
-if abspath(PROGRAM_FILE) == Pkg.dir(joinpath("Coverage", "src", "Coverage.jl"))
+if abspath(PROGRAM_FILE) == joinpath(dirname(@__FILE__), "Coverage.jl")
     bc = analyze_malloc_files(ARGS)
     println(bc)
 end

--- a/src/memalloc.jl
+++ b/src/memalloc.jl
@@ -56,7 +56,7 @@ isfuncexpr(ex::Expr) =
 isfuncexpr(arg) = false
 
 # Support Unix command line usage like `julia Coverage.jl $(find ~/.julia/v0.6 -name "*.jl.mem")`
-if abspath(PROGRAM_FILE) == joinpath(dirname(@__FILE__), "Coverage.jl")
+if abspath(PROGRAM_FILE) == joinpath(@__DIR__, "Coverage.jl")
     bc = analyze_malloc_files(ARGS)
     println(bc)
 end

--- a/src/memalloc.jl
+++ b/src/memalloc.jl
@@ -56,7 +56,7 @@ isfuncexpr(ex::Expr) =
 isfuncexpr(arg) = false
 
 # Support Unix command line usage like `julia Coverage.jl $(find ~/.julia/v0.3 -name "*.jl.mem")`
-if !isinteractive()
+if abspath(PROGRAM_FILE) == @__FILE__
     bc = analyze_malloc_files(ARGS)
     println(bc)
 end

--- a/src/memalloc.jl
+++ b/src/memalloc.jl
@@ -55,8 +55,8 @@ isfuncexpr(ex::Expr) =
     ex.head == :function || (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
 isfuncexpr(arg) = false
 
-# Support Unix command line usage like `julia Coverage.jl $(find ~/.julia/v0.3 -name "*.jl.mem")`
-if abspath(PROGRAM_FILE) == @__FILE__
+# Support Unix command line usage like `julia Coverage.jl $(find ~/.julia/v0.6 -name "*.jl.mem")`
+if abspath(PROGRAM_FILE) == Pkg.dir(joinpath("Coverage", "src", "Coverage.jl"))
     bc = analyze_malloc_files(ARGS)
     println(bc)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,7 @@ cd(dirname(@__DIR__)) do
         end
         """)
     @test readchomp(`$(Base.julia_cmd()) $script argument`) == "argument"
+    rm(script)
 
     # Test command-line usage
     @test readchomp(`$(Base.julia_cmd()) $(joinpath("src", "Coverage.jl"))`) == "Coverage.MallocInfo[]"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,21 @@ cd(dirname(@__DIR__)) do
     open("fakefile",true,true,true,false,false)
     @test isempty(Coverage.process_cov("fakefile",datadir))
     rm("fakefile")
+
+    # Test `using Coverage` with non-empty command-line arguments
+    script = tempname()
+    write(script, """
+        try
+            using Coverage
+            println(join(ARGS, ","))
+        catch
+            nothing
+        end
+        """)
+    @test readchomp(`$(Base.julia_cmd()) $script argument`) == "argument"
+
+    # Test command-line usage
+    @test readchomp(`$(Base.julia_cmd()) $(joinpath("src", "Coverage.jl"))`) == "Coverage.MallocInfo[]"
 end
 
 


### PR DESCRIPTION
This is weird to explain so here's an example:

```
[ ~ ] cat > x.jl
using Coverage
print(ARGS)
[ ~ ] julia x.jl fjsf
ERROR: LoadError: LoadError: LoadError: SystemError: opening file fjsf: No such file or directory
Stacktrace:
 [1] #systemerror#37 at ./error.jl:64 [inlined]
 [2] systemerror(::String, ::Bool) at ./error.jl:64
 [3] open(::String, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./iostream.jl:104
 [4] open(::Coverage.##17#18{Array{Coverage.MallocInfo,1}}, ::String) at ./iostream.jl:150
 [5] analyze_malloc_files(::Array{String,1}) at /Users/degraafc/.julia/v0.6/Coverage/src/memalloc.jl:20
 [6] include_from_node1(::String) at ./loading.jl:539
 [7] include(::String) at ./sysimg.jl:14
 [8] include_from_node1(::String) at ./loading.jl:539
while loading /Users/degraafc/.julia/v0.6/Coverage/src/memalloc.jl, in expression starting on line 60
while loading /Users/degraafc/.julia/v0.6/Coverage/src/Coverage.jl, in expression starting on line 272
while loading /Users/degraafc/x.jl, in expression starting on line 1
```

`isinteractive()` only deals with the REPL case, not the `using` case. This change deals with both! It looks like this problem has previously been identified in https://github.com/JuliaCI/Coverage.jl/issues/98#issuecomment-218820915.
