### PR TITLE
Add support for Circle CI

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -94,6 +94,23 @@ module Codecov
                 slug         = ENV["TRAVIS_REPO_SLUG"],
                 build        = ENV["TRAVIS_JOB_NUMBER"],
             )
+        elseif lowercase(get(ENV, "CIRCLECI", "false")) == "true"
+            circle_slug = join(
+                [
+                    ENV["CIRCLE_PROJECT_USERNAME"],
+                    ENV["CIRCLE_PROJECT_REPONAME"],
+                ],
+                "%2F",
+            )
+            kwargs = set_defaults(kwargs,
+                service      = "circleci",
+                branch       = ENV["CIRCLE_BRANCH"],
+                commit       = ENV["CIRCLE_SHA1"],
+                pull_request = ENV["CIRCLE_PR_NUMBER"],
+                build_url    = ENV["CIRCLE_BUILD_URL"],
+                slug         = circle_slug,
+                build        = ENV["CIRCLE_BUILD_NUM"],
+            )
         else
             error("No compatible CI platform detected")
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,4 +351,75 @@ withenv(
             end
         end
 
+    # test circle ci submission process
+
+    # set up circle ci env
+    withenv(
+        "CIRCLECI" => "true",
+        "CIRCLE_PR_NUMBER" => "t_pr",
+        "CIRCLE_PROJECT_USERNAME" => "t_proj",
+        "CIRCLE_BRANCH" => "t_branch",
+        "CIRCLE_SHA1" => "t_commit",
+        "CIRCLE_PROJECT_REPONAME" => "t_repo",
+        "CIRCLE_BUILD_URL" => "t_url",
+        "CIRCLE_BUILD_NUM" => "t_num",
+        ) do
+
+        # default values
+        codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
+        @test contains(codecov_url, "codecov.io")
+        @test contains(codecov_url, "service=circleci")
+        @test contains(codecov_url, "branch=t_branch")
+        @test contains(codecov_url, "commit=t_commit")
+        @test contains(codecov_url, "pull_request=t_pr")
+        @test contains(codecov_url, "build_url=t_url")
+        @test contains(codecov_url, "build=t_num")
+
+        # env var url override
+        withenv( "CODECOV_URL" => "https://enterprise-codecov-1.com" ) do
+
+            codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
+            @test contains(codecov_url, "enterprise-codecov-1.com")
+            @test contains(codecov_url, "service=circleci")
+            @test contains(codecov_url, "branch=t_branch")
+            @test contains(codecov_url, "commit=t_commit")
+            @test contains(codecov_url, "pull_request=t_pr")
+            @test contains(codecov_url, "build_url=t_url")
+            @test contains(codecov_url, "build=t_num")
+
+            # function argument url override
+            codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true, codecov_url = "https://enterprise-codecov-2.com") )
+            @test contains(codecov_url, "enterprise-codecov-2.com")
+            @test contains(codecov_url, "service=circleci")
+            @test contains(codecov_url, "branch=t_branch")
+            @test contains(codecov_url, "commit=t_commit")
+            @test contains(codecov_url, "pull_request=t_pr")
+            @test contains(codecov_url, "build_url=t_url")
+            @test contains(codecov_url, "build=t_num")
+
+            # env var token
+            withenv( "CODECOV_TOKEN" => "token_name_1" ) do
+
+                codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true) )
+                @test contains(codecov_url, "enterprise-codecov-1.com")
+                @test contains(codecov_url, "token=token_name_1")
+                @test contains(codecov_url, "service=circleci")
+                @test contains(codecov_url, "branch=t_branch")
+                @test contains(codecov_url, "commit=t_commit")
+                @test contains(codecov_url, "pull_request=t_pr")
+                @test contains(codecov_url, "build_url=t_url")
+                @test contains(codecov_url, "build=t_num")
+
+                # function argument token url override
+                codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit(fcs; dry_run = true, token="token_name_2") )
+                @test contains(codecov_url, "enterprise-codecov-1.com")
+                @test contains(codecov_url, "service=circleci")
+                @test contains(codecov_url, "branch=t_branch")
+                @test contains(codecov_url, "commit=t_commit")
+                @test contains(codecov_url, "pull_request=t_pr")
+                @test contains(codecov_url, "build_url=t_url")
+                @test contains(codecov_url, "build=t_num")
+            end
+        end
+    end
 end


### PR DESCRIPTION
It's the third CI platform supported by/supporting CodeCov by default so I think it's reasonable to support it in Coverage.jl.

I didn't include the `job` key (there's no unique job number in Circle CI) but I did include the `build_url` key. 