### PR TITLE
Require Git 0.2.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 JSON
 Requests
-Git
+Git 0.2.0
 Compat 0.9.5


### PR DESCRIPTION
In [Git 0.2.0 version](https://github.com/JuliaPackaging/Git.jl/releases/tag/v0.2.0) they [changed](https://github.com/JuliaPackaging/Git.jl/issues/13) Compat.UTF8String to String. This avoid the following warnings when calling `using Coverage`

```julia
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Git/src/Git.jl:72
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Coverage/src/memalloc.jl:3
WARNING: Compat.UTF8String is deprecated, use String instead.
  likely near /home/ale/.julia/v0.6/Coverage/src/memalloc.jl:3
```