### PR TITLE
Restructure Travis tests to be more transparent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ sudo: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("Coverage"; coverage=true)'
-after_success:
-  - julia -e 'cd(Pkg.dir("Coverage")); using Coverage; Coveralls.submit(process_folder())'
-  - julia -e 'cd(Pkg.dir("Coverage")); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'using Coverage; Coveralls.submit(process_folder())'
+  - julia -e 'using Coverage; Codecov.submit(process_folder())'


### PR DESCRIPTION
Currently coverage information is submitted in the `after_success` block of the Travis script, as it is in most packages. This makes sense for the vast majority of packages, since if coverage submission fails you don't want it to fail your build. However, that's exactly what we want to happen if submission fails here.

This commit restructures the tests to put the coverage submission in the `script` block. This should cause the build to fail if submission fails.