### PR TITLE
Fix our own coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ script:
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("Coverage"; coverage=true)'
   - julia -e 'using Coverage; Coveralls.submit(process_folder())'
   - julia -e 'using Coverage; Codecov.submit(process_folder())'
+after_success:
+  - if [ "$TRAVIS_JULIA_VERSION" != "nightly" ]; then
+      julia -e 'Pkg.rm("Coverage"); Pkg.add("Coverage")';
+      julia -e 'using Coverage; Coveralls.submit(process_folder())';
+      julia -e 'using Coverage; Codecov.submit(process_folder())';
+    fi

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@ Coverage.jl
 
 *Release version*:
 
-[![Coverage](http://pkg.julialang.org/badges/Coverage_0.3.svg)](http://pkg.julialang.org/?pkg=Coverage)
-[![Coverage](http://pkg.julialang.org/badges/Coverage_0.4.svg)](http://pkg.julialang.org/?pkg=Coverage)
-[![Coverage](http://pkg.julialang.org/badges/Coverage_0.5.svg)](http://pkg.julialang.org/?pkg=Coverage)
+[![Coverage](http://pkg.julialang.org/badges/Coverage_0.6.svg)](http://pkg.julialang.org/?pkg=Coverage)
+[![Coverage](http://pkg.julialang.org/badges/Coverage_0.7.svg)](http://pkg.julialang.org/?pkg=Coverage)
 
 *Development version*:
 


### PR DESCRIPTION
This submits coverage using the most recently tagged version on success. It also updates the badges in the README to reflect that we support 0.6 and 0.7 only now.