### PR TITLE
Fix error when coverage vector is empty

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -48,8 +48,13 @@ module Coverage
     function get_summary end
 
     function get_summary(fc::FileCoverage)
-        cov_lines = sum(x -> x!=nothing && x > 0, fc.coverage)
-        tot_lines = sum(x -> x!=nothing, fc.coverage)
+        if !isempty(fc.coverage)
+            cov_lines = sum(x -> x !== nothing && x > 0, fc.coverage)
+            tot_lines = sum(x -> x !== nothing, fc.coverage)
+        else
+            cov_lines = 0
+            tot_lines = 0
+        end
         return cov_lines, tot_lines
     end
     function get_summary(fcs::Vector{FileCoverage})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,10 @@ cd(dirname(@__DIR__)) do
     @test get_summary(r) == covtarget
     @test get_summary(process_folder(datadir)) != covtarget
 
+    # Handle an empty coverage vector
+    emptycov = FileCoverage("", "", [])
+    @test get_summary(emptycov) == (0, 0)
+
     #json_data = Codecov.build_json_data(Codecov.process_folder("data"))
     #@test typeof(json_data["coverage"]["data/Coverage.jl"]) == Array{Union{Int64,Nothing},1}
     open("fakefile",true,true,true,false,false)


### PR DESCRIPTION
Noticed this error on Julia 0.6.3 with Coverage 0.5.3:
```
...
Coverage.process_folder: Skipping utils.jl.565.cov, not a .jl file
ERROR: LoadError: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
 [1] _mapreduce(::Coverage.##1#3, ::Base.#+, ::IndexLinear, ::Array{Union{Int64, Void},1}) at ./reduce.jl:265
 [2] get_summary(::Coverage.FileCoverage) at /root/.julia/v0.6/Coverage/src/Coverage.jl:51
 [3] get_summary(::Array{Coverage.FileCoverage,1}) at /root/.julia/v0.6/Coverage/src/Coverage.jl:58
 [4] (::##1#2)() at /usr/local/bin/julia-coverage:25
 [5] cd(::##1#2, ::String) at ./file.jl:70
 [6] include_from_node1(::String) at ./loading.jl:576
 [7] include(::String) at ./sysimg.jl:14
 [8] process_options(::Base.JLOptions) at ./client.jl:305
 [9] _start() at ./client.jl:371
```