### PR TITLE
Adding verbose flag to codecovio

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -212,12 +212,16 @@ module Codecov
 
         codecov_url = "https://codecov.io"
         dry_run = false
+        verbose = true
         for (k,v) in kwargs
             if k == :codecov_url
                 codecov_url = v
             end
             if k == :dry_run
                 dry_run = true
+            end
+            if k == :verbose
+                verbose = v
             end
         end
         @assert codecov_url[end] != "/" "the codecov_url should not end with a /, given url $(codecov_url)"
@@ -229,8 +233,10 @@ module Codecov
             end
         end
 
-        println("Codecov.io API URL:")
-        println(uri_str)
+        if verbose
+            println("Codecov.io API URL:")
+            println(uri_str)
+        end
 
         if !dry_run
             heads   = Dict("Content-Type" => "application/json")

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -228,7 +228,7 @@ module Codecov
 
         uri_str = "$(codecov_url)/upload/v2?"
         for (k,v) in kwargs
-            if k != :codecov_url && k != :dry_run
+            if k != :codecov_url && k != :dry_run && k != :verbose
                 uri_str = "$(uri_str)&$(k)=$(v)"
             end
         end


### PR DESCRIPTION
This addition of the `verbose` flag avoids printing the token on a CI when submitting the coverage report.