### PR TITLE
Fix Meta.parse call on 32-bit

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -38,7 +38,7 @@ end
 if VERSION >= v"0.7.0-DEV.2437"
     function _parse(io::IO)
         # position(io) is 0-based
-        Meta.parse(read(io, String), position(io)+1)
+        Meta.parse(read(io, String), Int(position(io) + 1))
     end
 else
     _parse(io::IO) = Base.parse(io)


### PR DESCRIPTION
The `position` function will always return an `Int64` while the `Meta.parse` only accepts an `Int`. This means that when running 32-bit Julia `Meta.parse` will only accept an `Int32` which causes this call to fail.