### PR TITLE
Skip Codecov.submit_local test if not in a git repo; Use LibGit2.GitRepoExt to (try to) load git repository

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -158,8 +158,8 @@ module Codecov
     a local git installation, rooted at `dir`. A repository token should be specified by a
     `token` keyword argument or the `CODECOV_TOKEN` environment variable.
     """
-    function submit_local(fcs::Vector{FileCoverage}, dir::AbstractString=joinpath(pwd(),".."); kwargs...)
-        LibGit2.with(LibGit2.GitRepo(dir)) do repo
+    function submit_local(fcs::Vector{FileCoverage}, dir::AbstractString=pwd(); kwargs...)
+        LibGit2.with(LibGit2.GitRepoExt(dir)) do repo
             LibGit2.with(LibGit2.head(repo)) do headref
                 branch_name = LibGit2.shortname(headref) # this function returns a String
                 commit_oid  = LibGit2.GitHash(LibGit2.peel(headref))

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -110,7 +110,7 @@ module Coveralls
     # Pulls information about the repository that isn't available if we
     # are running somewhere other than TravisCI
     function query_git_info(dir=pwd())
-        repo            = LibGit2.GitRepo(dir)
+        repo            = LibGit2.GitRepoExt(dir)
         head            = LibGit2.head(repo)
         head_cmt        = LibGit2.peel(head)
         head_oid        = LibGit2.GitHash(head_cmt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 # https://github.com/JuliaCI/Coverage.jl
 #######################################################################
 
-using Coverage, Compat, Compat.Test
+using Coverage, Compat, Compat.Test, Compat.LibGit2
 using Suppressor
 
 @testset "Coverage" begin
@@ -146,44 +146,47 @@ end
         "APPVEYOR_JOB_ID" => nothing,
         ) do
 
-        # test local submission process
+        # test local submission process (but only if we are in a git repo)
 
-        # default values
-        codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
-        @test occursin("codecov.io", codecov_url)
-        @test occursin("commit", codecov_url)
-        @test occursin("branch", codecov_url)
-        @test !occursin("service", codecov_url)
+        LibGit2.with(LibGit2.GitRepoExt(pwd())) do repo
 
-        # env var url override
-        withenv( "CODECOV_URL" => "https://enterprise-codecov-1.com" ) do
-
+            # default values
             codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
-            @test occursin("enterprise-codecov-1.com", codecov_url)
+            @test occursin("codecov.io", codecov_url)
             @test occursin("commit", codecov_url)
             @test occursin("branch", codecov_url)
             @test !occursin("service", codecov_url)
 
-            # function argument url override
-            codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true, codecov_url = "https://enterprise-codecov-2.com") )
-            @test occursin("enterprise-codecov-2.com", codecov_url)
-            @test occursin("commit", codecov_url)
-            @test occursin("branch", codecov_url)
-            @test !occursin("service", codecov_url)
-
-            # env var token
-            withenv( "CODECOV_TOKEN" => "token_name_1" ) do
+            # env var url override
+            withenv( "CODECOV_URL" => "https://enterprise-codecov-1.com" ) do
 
                 codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
                 @test occursin("enterprise-codecov-1.com", codecov_url)
-                @test occursin("token=token_name_1", codecov_url)
+                @test occursin("commit", codecov_url)
+                @test occursin("branch", codecov_url)
                 @test !occursin("service", codecov_url)
 
-                # function argument token url override
-                codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true, token="token_name_2") )
-                @test occursin("enterprise-codecov-1.com", codecov_url)
-                @test occursin("token=token_name_2", codecov_url)
+                # function argument url override
+                codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true, codecov_url = "https://enterprise-codecov-2.com") )
+                @test occursin("enterprise-codecov-2.com", codecov_url)
+                @test occursin("commit", codecov_url)
+                @test occursin("branch", codecov_url)
                 @test !occursin("service", codecov_url)
+
+                # env var token
+                withenv( "CODECOV_TOKEN" => "token_name_1" ) do
+
+                    codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true) )
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("token=token_name_1", codecov_url)
+                    @test !occursin("service", codecov_url)
+
+                    # function argument token url override
+                    codecov_url = extract_codecov_url( () -> Coverage.Codecov.submit_local(fcs; dry_run = true, token="token_name_2") )
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("token=token_name_2", codecov_url)
+                    @test !occursin("service", codecov_url)
+                end
             end
         end
 


### PR DESCRIPTION
This should fix the test failures reported by JuliaCIBot on https://github.com/JuliaLang/METADATA.jl/pull/19092

Also use `LibGit2.GitRepoExt` instead of `LibGit2.GitRepo` to (try to) load git repository. This should fix #159 and render #160 obsolete.