### PR TITLE
Let amend_coverage_from_src! skip partially covered code (WIP)

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -178,10 +178,19 @@ module Coverage
             flines = function_body_lines(ast)
             if !isempty(flines)
                 flines .+= linestart-1
+
+                if any(l -> l > length(coverage), flines)
+                    error("source file is longer than .cov file; source might have changed")
+                end
+
+                # If any line has coverage, assume that Julia executed this code, and
+                # don't modify any coverage data. This works around issues with inlined
+                # code, see https://github.com/JuliaCI/Coverage.jl/issues/187
+                if any(l -> coverage[l] != nothing, flines)
+                    continue
+                end
+
                 for l in flines
-                    if l > length(coverage)
-                        error("source file is longer than .cov file; source might have changed")
-                    end
                     if coverage[l] === nothing
                         coverage[l] = 0
                     end


### PR DESCRIPTION
This is meant to fix issue #187, or at least reduce the problem, by not applying `amend_coverage_from_src!` to functions which already have some coverage information, based on the idea that those functions were executed by Julia, and the coverage information therein then should just be "trusted".

There are various issues with this in its current state, but I don't have more time right now to tune it, so I though it's better to post this now in case people like @ronisbr or @tkoolen are interested in giving it a spin.

Among the problems are:

* this does not yet deal properly with modules: `Meta.parse` will read a whole module in one go; but then unused functions in that module are not marked as code again. So the code needs to be refined to look inside modules, and then iterate over the functions therein. In fact it probably needs to traverse the whole AST and treat each function separately, to also deal with nested functions. Ho-hum. It would be really nice if we didn't have to do any of this, and Julia just did the "right thing" for functions that are never executed (whatever that means exactly...)

Example: `src/Coverage.jl` from this package [with master resp. 0.7.0](https://codecov.io/gh/fingolfin/Coverage.jl/src/master/src/Coverage.jl#L236) vs. [with this PR](https://codecov.io/gh/fingolfin/Coverage.jl/src/mh%2Fskip-partially-covered-code/src/Coverage.jl#L245)

* There are more things where coverage now again is artificially too high. E.g. it seems `with` blocks also may need special treatment: [correct coverage with master](https://codecov.io/gh/fingolfin/Coverage.jl/src/master/src/memalloc.jl#L19), [incorrect with this PR](https://codecov.io/gh/fingolfin/Coverage.jl/src/mh%2Fskip-partially-covered-code/src/memalloc.jl#L19).

Note that both of these issues of course would also appear if `amend_coverage_from_src!` was simply removed.

On the plus side, I suspect that e.g. the example by @tkooolen for [coverage in `StaticArrays.jl/src/eigen.jl`](
https://codecov.io/gh/JuliaArrays/StaticArrays.jl/src/1683f798e0dcb8725768407053a45ae48434fed7/src/eigen.jl#L39) will look a lot better, because a lot of the red lines will turn into gray/white (= "not code") again.

I can try to see if things can be improved, but I'll have to learn how the AST returned by `Meta.parse` works... If somebody more knowledgeable than me on these things (e.g. some actual Julia developers) wants to take over, be my guest ;-).