### PR TITLE
WIP: Allow coverage submission from Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+freebsd_instance:
+  image: freebsd-11-2-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+        COVERALLS_TOKEN: "e3NzCKR7to16VWKJtXcNk4QKOPfz3GwZH"
+      - JULIA_VERSION: 1.1
+        COVERALLS_TOKEN: "e3NzCKR7to16VWKJtXcNk4QKOPfz3GwZH"
+      - JULIA_VERSION: nightly
+        COVERALLS_TOKEN: "e3NzCKR7to16VWKJtXcNk4QKOPfz3GwZH"
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - julia --project=. --code-coverage=user etc/travis-coverage.jl
+    - julia --project=. etc/travis-coverage.jl

--- a/etc/travis-coverage.jl
+++ b/etc/travis-coverage.jl
@@ -1,4 +1,8 @@
 using Coverage
 cov_res = process_folder()
-Coveralls.submit(cov_res)
+if Sys.KERNEL === :FreeBSD
+    @info "Skipping Coveralls on FreeBSD"
+else
+    Coveralls.submit(cov_res)
+end
 Codecov.submit(cov_res)

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -111,6 +111,15 @@ module Codecov
                 slug         = circle_slug,
                 build        = ENV["CIRCLE_BUILD_NUM"],
             )
+        elseif lowercase(get(ENV, "CIRRUS_CI", "false")) == "true"
+            kwargs = set_defaults(kwargs,
+                service      = "cirrus",
+                branch       = ENV["CIRRUS_BRANCH"],
+                commit       = ENV["CIRRUS_CHANGE_IN_REPO"],
+                pull_request = get(ENV, "CIRRUS_PR", "false"),
+                slug         = ENV["CIRRUS_REPO_FULL_NAME"],
+                build        = ENV["CIRRUS_BUILD_ID"],
+            )
         elseif lowercase(get(ENV, "JENKINS", "false")) == "true"
             kwargs = set_defaults(kwargs,
                 service      = "jenkins",

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -74,6 +74,9 @@ module Coveralls
             if get(ENV, "CI_PULL_REQUEST", "false") == "false"
                 data["git"]["branch"] = split(ENV["GIT_BRANCH"], "/")[2]
             end
+        elseif lowercase(get(ENV, "CIRRUS_CI", "false")) == "true"
+            data["service_job_id"] = ENV["CIRRUS_BUILD_ID"]
+            data["service_name"] = "cirrus"
         else
             error("No compatible CI platform detected")
         end


### PR DESCRIPTION
This will permit coverage submission from builds running on [Cirrus CI](https://cirrus-ci.org), which will fix the coverage step in [my Cirrus template](https://github.com/ararslan/CirrusCI.jl).

Currently a work in progress as I have no idea if this works.