### PR TITLE
Fixed test that failed on Windows due to line endings

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
         LCOV.write(lcov, FileCoverage[r])
         expected = read(joinpath(datadir, "tracefiles", "expected.info"), String)
         if Sys.iswindows()
+            expected = replace(expected, "\r\n" => "\n")
             expected = replace(expected, "SF:test/data/Coverage.jl\n" => "SF:test\\data\\Coverage.jl\n")
         end
         @test String(take!(lcov)) == expected


### PR DESCRIPTION
The Windows line endings show up as `\r\n` on my machine in `expected`, while the `IOBuffer` returns `\n`. Not sure why this does not fail for others/AppVeyor, though. 