### PR TITLE
Factored out create_uri_string_* methods for easier testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,7 @@ HTTP = ">=0.8.0"
 julia = "0.7, 1.0"
 
 [extras]
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Suppressor"]
+test = ["Test"]


### PR DESCRIPTION
Removes the need for Suppressor, and better shows what is actually tested with the dry run, namely generating the token. When changing this code, I also realized that `submit_generic()`, although exported, is probably not used outside the package? I.e., for CI one would use `submit()`, and for local `submit_local()`. Should that export be removed?