### PR TITLE
Make sure tests are robust with respect to Win line endings

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
         LCOV.write(lcov, FileCoverage[r])
         expected = read(joinpath(datadir, "tracefiles", "expected.info"), String)
         if Sys.iswindows()
+            expected = replace(expected, "\r\n" => "\n")
             expected = replace(expected, "SF:test/data/Coverage.jl\n" => "SF:test\\data\\Coverage.jl\n")
         end
         @test String(take!(lcov)) == expected


### PR DESCRIPTION
The default config for git on Windows is to use `\r\n` line endings, and that breaks the tests. This patch should fix that.