### PR TITLE
Only add lines from function bodies for coverage

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3,6 +3,9 @@
 isevaldef(x) = Base.Meta.isexpr(x, :(=)) && Base.Meta.isexpr(x.args[1], :call) &&
                x.args[1].args[1] == :eval
 
+# This detects two types of function declarations: those that use the
+# `function` keyword (first case) and those that are defined as
+# `f() = expr` (the second case).
 isfuncexpr(ex::Expr) =
     ex.head == :function || (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
 isfuncexpr(arg) = false
@@ -33,9 +36,21 @@ function function_body_lines!(flines, ast::Expr, infunction)
         args = ast.args
     end
 
-    if isfuncexpr(ast) && length(args)>=2 && args[2] isa Expr
-        # Only look in function body
-        for arg in args[2].args
+    # Check whether we are looking at a function declaration.
+    # Then also make sure we are not looking at a function declaration
+    # that does not also define a method by checking the length of
+    # ast.args and making sure it is at least length==2. The test for
+    # Expr might not be necessary but also can't harm. Note that this works
+    # for both function declarations that use the `function` keyword, and
+    # declarations of the form `foo() = expr`, in both cases the method
+    # body ends up being `ast.args[2]` (if it exists).
+    if isfuncexpr(ast) && length(ast.args)>=2 && ast.args[2] isa Expr
+        # Only look in function body and ignore the function signature
+        # itself. Sometimes function signatures have line nodes inside
+        # and we don't want those lines to be identified as runnable code.
+        # In this context, ast.args[1] is the function signature and
+        # ast.args[2] is the method body
+        for arg in ast.args[2].args
             flines = function_body_lines!(flines, arg, true)
         end
     else

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -32,9 +32,17 @@ function function_body_lines!(flines, ast::Expr, infunction)
     else
         args = ast.args
     end
-    infunction |= isfuncexpr(ast)
-    for arg in args
-        flines = function_body_lines!(flines, arg, infunction)
+
+    if isfuncexpr(ast) && length(args)>=2 && args[2] isa Expr
+        # Only look in function body
+        for arg in args[2].args
+            flines = function_body_lines!(flines, arg, true)
+        end
+    else
+        for arg in args
+            flines = function_body_lines!(flines, arg, infunction)
+        end
     end
+
     flines
 end


### PR DESCRIPTION
Fixes #199.

There are certain function signatures that have a line node in their AST, and then the function signature gets marked as uncovered. That is not good, because there is then no way to actually cover that line. So this just skips the function signature part, and only looks at the body of functions when it comes to amend the line info reported from base.