### PR TITLE
Restore HTTP.post invocation

### DIFF
--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -161,10 +161,7 @@ module Coveralls
             @info "Submitting data to Coveralls..."
         end
 
-        url = "https://coveralls.io/api/v1/jobs"
-        body = HTTP.Form(makebody(data))
-        headers = ["Content-Type" => "multipart/form-data; boundary=$(body.boundary)"]
-        req = HTTP.post(url, headers, body)
+        req = HTTP.post("https://coveralls.io/api/v1/jobs", HTTP.Form(makebody(data)))
 
         if verbose
             @info "Result of submission:\n" * String(req.body)


### PR DESCRIPTION
In PR #196, part of the changes in PR #197 were reverted, I think by accident (or rather, due to my fault, when rebasing the former I was unaware of the changes in PR #197 which had already been merged some time ago).

This PR restores this. However, I am not 100% sure this is even right; there was a reason we added those http headers. I am assuming the point behind PR #197 was that this is not necessary anymore -- but neither the description of that PR, nor the commits in it, actually explain this (only says this is meant to "fix compatibility with HTTP 0.8 -- but curiously, merging PR #196 did not seem to break any tests?).

So before merging this, I'd like to verify that the cause for the addition of those explicit headers is indeed gone now (discussion of that is on PR #175). I am assuming it is the case, though, due to https://github.com/JuliaWeb/HTTP.jl/commit/01a2cff816e3cd6095990b80167f216cb26e906c ...

Anyway, @ararslan will know and then can decide whether to merge this PR here or not :-).