### PR TITLE
Check DISABLE_AMEND_COVERAGE_FROM_SRC env var

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -203,7 +203,9 @@ module Coverage
     function process_file(filename, folder)
         @info "Coverage.process_file: Detecting coverage for $filename"
         coverage = process_cov(filename,folder)
-        amend_coverage_from_src!(coverage, filename)
+        if get(ENV, "DISABLE_AMEND_COVERAGE_FROM_SRC", "no") != "yes"
+            amend_coverage_from_src!(coverage, filename)
+        end
         return FileCoverage(filename, read(filename, String), coverage)
     end
     process_file(filename) = process_file(filename,splitdir(filename)[1])


### PR DESCRIPTION
If the environment variable DISABLE_AMEND_COVERAGE_FROM_SRC is set to `yes`, do not call `amend_coverage_from_src!`. This is an optional mitigation for issue #187, and in general makes it easier to test the impact of amending the coverage data.