### PR TITLE
Update AppVeyor badge to point to JuliaCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Coverage.jl
 ===========
 
 [![Build Status](https://travis-ci.org/JuliaCI/Coverage.jl.svg?branch=master)](https://travis-ci.org/JuliaCI/Coverage.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/ooubhlayk9uek2kr/branch/master?svg=true)](https://ci.appveyor.com/project/ararslan/coverage-jl/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/07fkrnj70sevoqny?svg=true)](https://ci.appveyor.com/project/JuliaCI/coverage-jl)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaCI/Coverage.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaCI/Coverage.jl?branch=master)
 [![codecov](https://codecov.io/gh/JuliaCI/Coverage.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaCI/Coverage.jl)
 


### PR DESCRIPTION
AppVeyor has changed their permissions model such that builds can run per organization rather than having to be under a specific user's account. I've authorized the AppVeyor integration for the JuliaCI
organization and set up builds for this repo after disabling it running under my account. This simply changes the badge URL to point to the new location.

cc @fingolfin 