### PR TITLE
Improve coverage heuristic in function_body_lines

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -175,7 +175,7 @@ module Coverage
             linestart = minimum(searchsorted(linepos, pos - 1))
             ast, pos = Meta.parse(content, pos)
             isa(ast, Expr) || continue
-            flines = function_body_lines(ast)
+            flines = function_body_lines(ast, coverage, linestart - 1)
             if !isempty(flines)
                 flines .+= linestart-1
                 for l in flines


### PR DESCRIPTION
Improve coverage heuristic in function_body_lines

The purpose of function_body_lines is to find functions which are "dead" (= never executed by test suite), and mark them as code, because Julia's built-in coverage code does not do that; if we were to rely on it, such functions would be marked as non-code, and thus they do not show up in the overall code coverage percentage.

But our current heuristic is too aggressive in so far as that Julia also sometimes marks code lines as "is not code" in the middle of functions that are being executed (most likely due to inlining and other optimizations). If we mark those lines as code, they will show up as uncovered, with no way for the package author to change this.

With this commit, we refine our heuristic: we only apply it to functions for which Julia recorded no coverage at all, as before; but if even just one line in the function body has coverage information, we do not touch the code lines in it at all.

Some care must be taken to make sure this works right for nested functions.

Closes #188
