### PR TITLE
Handle more types of function declarations

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3,11 +3,15 @@
 isevaldef(x) = Base.Meta.isexpr(x, :(=)) && Base.Meta.isexpr(x.args[1], :call) &&
                x.args[1].args[1] == :eval
 
-# This detects two types of function declarations: those that use the
-# `function` keyword (first case) and those that are defined as
-# `f() = expr` (the second case).
+# This detects different types of function declarations:
+# - those that use the  `function` keyword;
+# - those that are defined as `f = x -> expr`
+# - those that are defined as `f() = expr`
+# - those that are defined as `f() where {T} = expr`
 isfuncexpr(ex::Expr) =
-    ex.head == :function || (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
+    ex.head == :function || ex.head == :-> ||
+        (ex.head == :(=) && typeof(ex.args[1]) == Expr &&
+            (ex.args[1].head == :call || (ex.args[1].head == :where && ex.args[1].args[1].head == :call)))
 isfuncexpr(arg) = false
 
 function_body_lines(ast, coverage, lineoffset) = function_body_lines!(Int[], ast, coverage, lineoffset, false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,15 @@ end
 end
 
 @testset "isfuncexpr" begin
+    @test Coverage.isfuncexpr(:(f() = x))
+    @test Coverage.isfuncexpr(:(function() end))
+    @test Coverage.isfuncexpr(:(function g() end))
+    @test Coverage.isfuncexpr(:(function g() where {T} end))
     @test !Coverage.isfuncexpr("2")
+    @test !Coverage.isfuncexpr(:(f = x))
+    @test Coverage.isfuncexpr(:(() -> x))
+    @test Coverage.isfuncexpr(:(x -> x))
+    @test Coverage.isfuncexpr(:(g() where {T} = 3))
 end
 
 @testset "Processing coverage" begin


### PR DESCRIPTION
Motivated by parts of PR #214.

A real life example of dead code not found because of this can be seen [here in the JuliaSpace/ReferenceFrameRotations.jl project](https://codecov.io/gh/JuliaSpace/ReferenceFrameRotations.jl/src/master/src/quaternion.jl#L77) (CC @ronisbr). Just in case the line numbers change, the function in question is this
```julia
Quaternion{T}(u::UniformScaling) where T = Quaternion{T}(T(u.λ), T(0), T(0), T(0))
```