### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -180,7 +180,7 @@ module Coveralls
                         end
                     end
                 end
-        if repo_token != nothing
+        if repo_token !== nothing
             data["repo_token"] = repo_token
         end
         return data


### PR DESCRIPTION
- add some spaces after commas
- use !== instead of != to compare against nothing
- simplify a test by adding empty test/fakefile to repository
- use repr in a test instead of (ab)using escape_string
- use searchsortedfirst(...) instead of minimum(searchsorted(...)0
- rename linestart to lineoffset
- subtract 1 from lineoffset at definition, simplifies (?) following code
- test effect of DISABLE_AMEND_COVERAGE_FROM_SRC
- make tests work if DISABLE_AMEND_COVERAGE_FROM_SRC=yes is set
- fix a typo in a comment
- make a get_summary test more precise

This extracts a bunch of changes from PR #214 that IMHO don't belong in there, logically. We can merge this here quickly, I think, and then rebase PR #214 (I verified that rebasing that is mostly straight forwards, and can also update that PR if desired).

My goal to separating this here is so that I can more easily see and review the core of PR #214. So (how) should I acknowledge that these changes are all essentially thanks to @vtjnash ? 