### PR TITLE
Remove verbose flag, change some @info to @debug

### DIFF
--- a/src/Coverage.jl
+++ b/src/Coverage.jl
@@ -133,6 +133,7 @@ module Coverage
         # Keep track of the combined coverage
         full_coverage = CovCount[]
         for file in files
+            @info "Coverage.process_cov: processing $file"
             coverage = CovCount[]
             for line in eachline(file)
                 # Columns 1:9 contain the coverage count
@@ -232,7 +233,7 @@ module Coverage
     where Coverage is called from the root directory of a package.
     """
     function process_folder(folder="src")
-        @info """Coverage.process_folder: Searching $folder for .jl files..."""
+        @info "Coverage.process_folder: Searching $folder for .jl files..."
         source_files = FileCoverage[]
         files = readdir(folder)
         for file in files
@@ -242,7 +243,7 @@ module Coverage
                 if splitext(fullfile)[2] == ".jl"
                     push!(source_files, process_file(fullfile, folder))
                 else
-                    @info "Coverage.process_folder: Skipping $file, not a .jl file"
+                    @debug "Coverage.process_folder: Skipping $file, not a .jl file"
                 end
             elseif isdir(fullfile)
                 # If it is a folder, recursively traverse

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -56,7 +56,13 @@ module Coveralls
     on TravisCI, AppVeyor or Jenkins. If running locally, use `submit_local`.
     """
     function submit(fcs::Vector{FileCoverage}; kwargs...)
-        verbose = get(kwargs, :verbose, true)
+        if haskey(kwargs, :verbose)
+            Base.depwarn("The verbose keyword argument is deprecated, set the environment variable " *
+                         "JULIA_DEBUG=Coverage for verbose output", :submit_generic)
+            verbose = kwargs[:verbose]
+        else
+            verbose = false
+        end
         data = prepare_request(fcs, false)
         post_request(data, verbose)
     end
@@ -157,8 +163,14 @@ module Coveralls
     git_info can be either a `Dict` or a function that returns a `Dict`.
     """
     function submit_local(fcs::Vector{FileCoverage}, git_info=query_git_info; kwargs...)
+        if haskey(kwargs, :verbose)
+            Base.depwarn("The verbose keyword argument is deprecated, set the environment variable " *
+                         "JULIA_DEBUG=Coverage for verbose output", :submit_generic)
+            verbose = kwargs[:verbose]
+        else
+            verbose = false
+        end
         data = prepare_request(fcs, true, git_info)
-        verbose = get(kwargs, :verbose, true)
         post_request(data, verbose)
     end
 
@@ -166,7 +178,7 @@ module Coveralls
     function post_request(data, verbose)
         verbose && @info "Submitting data to Coveralls..."
         req = HTTP.post("https://coveralls.io/api/v1/jobs", HTTP.Form(makebody(data)))
-        verbose && @info "Result of submission:\n" * String(req.body)
+        verbose && @debug "Result of submission:\n" * String(req.body)
     end
 
     # adds the repo token to the data

--- a/src/lcov.jl
+++ b/src/lcov.jl
@@ -130,7 +130,7 @@ function readfolder(folder)
             if endswith(fullfile, ".info")
                 append!(source_files, readfile(fullfile))
             else
-                @info "Coverage.LCOV.readfolder: Skipping $file, not a .info file"
+                @debug "Coverage.LCOV.readfolder: Skipping $file, not a .info file"
             end
         elseif isdir(fullfile)
             # If it is a folder, recursively traverse


### PR DESCRIPTION
There is no point in Coverage.LCOV.readfolder and Coverage.clean_folder
reporting every file they did *not* process; this just clogs up build logs,
and almost always is useless; so change this from @info to @debug.

Also, by default user won't want to know the JSON replies of Codecov and
Coveralls, nor the exact URL we used to submit to Codecov, so change those
from @info to @debug as well.

On the other hand, knowing which files actually are being processed *is*
useful, so add an @info message for that (I recently had an exception thrown
in that code and had a hard time figuring out which file was being proceed, so
this will help).

Finally, get rid of the `verbose` keyword flag; instead, users can adjust the
logging level to suppress or show various messages.
