### PR TITLE
Mask codecov token in logs

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -195,7 +195,7 @@ module Codecov
         uri_str = construct_uri_string(;kwargs...)
 
         if verbose
-            @info "Codecov.io API URL:\n" * uri_str
+            @info "Codecov.io API URL:\n" * mask_token(uri_str)
         end
 
         if !dry_run
@@ -231,6 +231,10 @@ module Codecov
         end
 
         return uri_str
+    end
+
+    function mask_token(uri_string)
+        return replace(uri_string, r"token=[^&]*" => "token=<HIDDEN>")
     end
 
 end  # module Codecov

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -523,6 +523,32 @@ end
                 end
             end
         end
+
+        # test codecov token masking
+        withenv(
+            "APPVEYOR" => "true",
+            "APPVEYOR_PULL_REQUEST_NUMBER" => "t_pr",
+            "APPVEYOR_ACCOUNT_NAME" => "t_account",
+            "APPVEYOR_PROJECT_SLUG" => "t_slug",
+            "APPVEYOR_BUILD_VERSION" => "t_version",
+            "APPVEYOR_REPO_BRANCH" => "t_branch",
+            "APPVEYOR_REPO_COMMIT" => "t_commit",
+            "APPVEYOR_REPO_NAME" => "t_repo",
+            "APPVEYOR_JOB_ID" => "t_job_num",
+            "CODECOV_URL" => "https://enterprise-codecov-1.com",
+            "CODECOV_TOKEN" => "token_name_1"
+            ) do
+                codecov_url = construct_uri_string_ci()
+                masked = Coverage.Codecov.mask_token(codecov_url)
+                @test !occursin("token_name_1", masked)
+                @test occursin("token=<HIDDEN>", masked)
+        end
+
+        # in the case above, the token is at the end. Let's test explicitly,
+        # that this also works if the token occurs earlier in the url
+        url = "https://enterprise-codecov-1.com/upload/v2?token=token_name_1&build=t_job_num"
+        masked = Coverage.Codecov.mask_token(url)
+        @test masked == "https://enterprise-codecov-1.com/upload/v2?token=<HIDDEN>&build=t_job_num"
     end
 end
 


### PR DESCRIPTION
Reimplements #113 .

I have taken a different approach to the original PR: instead of splitting the url construction logic I left that as-is, and used a regex on the full string instead. That makes testing a bit easier as well.

One potential problem might be the line
```
            @info "Result of submission:" * String(req)
```
Does this print the url string as well?