### PR TITLE
Delete REQUIRE file

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 1.0
-JSON
-HTTP 0.8.0
-MbedTLS


### PR DESCRIPTION
Now that there is a `Project.toml` file, we can delete the `REQUIRE` file.