### PR TITLE
Delete test/REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Suppressor 0.1.1


### PR DESCRIPTION
We no longer have Suppressor.jl as a test-only dependency, so we can safely remove `test/REQUIRE`.