### PR TITLE
Delete REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Suppressor 0.1.1


### PR DESCRIPTION
We no longer have any test-only dependencies, so we can delete `test/REQUIRE`.