### PR TITLE
Coveralls - support PR for local submission

### DIFF
--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -74,6 +74,8 @@ module Coveralls
         if local_env
             # Attempt to parse git info via git_info, unless the user explicitly disables it by setting git_info to nothing
             data["git"] = parse_git_info(git_info)
+            pr = get(ENV, "PULL_REQUEST", "")
+            isempty(pr) || (data["service_pull_request"] = pr)
         elseif lowercase(get(ENV, "APPVEYOR", "false")) == "true"
             data["service_job_id"] = ENV["APPVEYOR_JOB_ID"]
             data["service_name"] = "appveyor"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -589,6 +589,10 @@ withenv(
                 @test !haskey(request, "service_job_id")
                 @test !haskey(request, "service_name")
                 @test !haskey(request, "service_pull_request")
+                withenv("PULL_REQUEST" => "7") do
+                    request = Coverage.Coveralls.prepare_request(fcs, true)
+                    @test request["service_pull_request"] == "7"
+                end
         end
 
         # test APPVEYOR


### PR DESCRIPTION
Related to #281, I am doing local submission before I can hook  up with a CI. And, I want the local submission to refer to a GitHub Enterprise PR. 

This PR adds support for a new `PULL_REQUEST` environment variable. When this variable is set, it is sent to Coveralls server accordingly.