### PR TITLE
Coveralls: fix error reporting printing

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -234,7 +234,8 @@ module Codecov
         verbose && @debug "Codecov.io API URL:\n" * mask_token(uri_str)
 
         if !dry_run
-            heads   = Dict("Content-Type" => "application/json")
+            heads   = Dict("Content-Type" => "application/json",
+                           "Accept" => "application/json")
             data    = to_json(fcs)
             req     = HTTP.post(uri_str; body = JSON.json(data), headers = heads)
             @debug "Result of submission:" * String(req)


### PR DESCRIPTION
Previously, this would print an html page, now it will print the error message

Fixes #276