### PR TITLE
memalloc: remove dead code

### DIFF
--- a/src/memalloc.jl
+++ b/src/memalloc.jl
@@ -5,9 +5,3 @@ const analyze_malloc = CoverageTools.analyze_malloc
 const analyze_malloc_files = CoverageTools.analyze_malloc_files
 const find_malloc_files = CoverageTools.find_malloc_files
 const sortbybytes = CoverageTools.sortbybytes
-
-# Support Unix command line usage like `julia Coverage.jl $(find ~/.julia/v0.6 -name "*.jl.mem")`
-if abspath(PROGRAM_FILE) == joinpath(@__DIR__, "Coverage.jl")
-    bc = analyze_malloc_files(ARGS)
-    println(bc)
-end


### PR DESCRIPTION
This is not how packages in Julia are used, especially since precompile. If we wanted something like this back, it would be more logical to have a simple script `bin/memalloc` to drive this functionality.

Closes #98