### PR TITLE
Add support for Buildkite.

### DIFF
--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -163,6 +163,18 @@ function add_ci_to_kwargs(kwargs::Dict)
             build        = ENV["GITHUB_RUN_ID"],
             build_url    = ga_build_url,
         )
+    elseif lowercase(get(ENV, "BUILDKITE", "false")) == "true"
+        kwargs = set_defaults(kwargs,
+            service      = "buildkite",
+            branch       = ENV["BUILDKITE_BRANCH"],
+            commit       = ENV["BUILDKITE_COMMIT"],
+            job          = ENV["BUILDKITE_JOB_ID"],
+            build        = ENV["BUILDKITE_BUILD_NUMBER"],
+            build_url    = ENV["BUILDKITE_BUILD_URL"]
+        )
+        if ENV["BUILDKITE_PULL_REQUEST"] != "false"
+            kwargs = set_defaults(kwargs, pr = ENV["BUILDKITE_PULL_REQUEST"])
+        end
     else
         error("No compatible CI platform detected")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -409,6 +409,79 @@ withenv(
             end
         end
 
+        # test Buildkite ci submission process
+
+        # set up Buildkite ci env
+        withenv(
+            "BUILDKITE" => "true",
+            "BUILDKITE_BRANCH" => "t_branch",
+            "BUILDKITE_COMMIT" => "t_commit",
+            "BUILDKITE_JOB_ID" => "t_job",
+            "BUILDKITE_BUILD_NUMBER" => "t_num",
+            "BUILDKITE_BUILD_URL" => "t_url",
+            "BUILDKITE_PULL_REQUEST" => "t_pr",
+            ) do
+
+            # default values
+            codecov_url = construct_uri_string_ci()
+            @test occursin("codecov.io", codecov_url)
+            @test occursin("service=buildkite", codecov_url)
+            @test occursin("branch=t_branch", codecov_url)
+            @test occursin("commit=t_commit", codecov_url)
+            @test occursin("build_url=t_url", codecov_url)
+            @test occursin("build=t_num", codecov_url)
+            @test occursin("pr=t_pr", codecov_url)
+
+            # without PR
+            withenv("BUILDKITE_PULL_REQUEST" => "false") do
+                codecov_url = construct_uri_string_ci()
+                @test !occursin("pr", codecov_url)
+            end
+
+            # env var url override
+            withenv( "CODECOV_URL" => "https://enterprise-codecov-1.com" ) do
+
+                codecov_url = construct_uri_string_ci()
+                @test occursin("enterprise-codecov-1.com", codecov_url)
+                @test occursin("service=buildkite", codecov_url)
+                @test occursin("branch=t_branch", codecov_url)
+                @test occursin("commit=t_commit", codecov_url)
+                @test occursin("build_url=t_url", codecov_url)
+                @test occursin("build=t_num", codecov_url)
+
+                # function argument url override
+                codecov_url = construct_uri_string_ci(codecov_url="https://enterprise-codecov-2.com")
+                @test occursin("enterprise-codecov-2.com", codecov_url)
+                @test occursin("service=buildkite", codecov_url)
+                @test occursin("branch=t_branch", codecov_url)
+                @test occursin("commit=t_commit", codecov_url)
+                @test occursin("build_url=t_url", codecov_url)
+                @test occursin("build=t_num", codecov_url)
+
+                # env var token
+                withenv( "CODECOV_TOKEN" => "token_name_1" ) do
+
+                    codecov_url = construct_uri_string_ci()
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("token=token_name_1", codecov_url)
+                    @test occursin("service=buildkite", codecov_url)
+                    @test occursin("branch=t_branch", codecov_url)
+                    @test occursin("commit=t_commit", codecov_url)
+                    @test occursin("build_url=t_url", codecov_url)
+                    @test occursin("build=t_num", codecov_url)
+
+                    # function argument token url override
+                    codecov_url = construct_uri_string_ci(token="token_name_2")
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("service=buildkite", codecov_url)
+                    @test occursin("branch=t_branch", codecov_url)
+                    @test occursin("commit=t_commit", codecov_url)
+                    @test occursin("build_url=t_url", codecov_url)
+                    @test occursin("build=t_num", codecov_url)
+                end
+            end
+        end
+
         # test codecov token masking
         withenv(
             "APPVEYOR" => "true",


### PR DESCRIPTION
Only added to Codecov, since as Coveralls [doesn't seem to support](https://docs.coveralls.io/supported-ci-services) Buildkite. Not that [Codecov supports tokenless uploads](https://community.codecov.com/t/buildkite-token-less-upload/2259) from Buildkite, but this at least avoids the need for local git operations to populate the branch, commit, etc.