### PR TITLE
Path to julia Appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ When using Coverage.jl locally, over time a lot of `.cov` files can accumulate. 
 
        ```yml
        after_test:
-       - C:\projects\julia\bin\julia -e "using Pkg; Pkg.add(\"Coverage\"); using Coverage; Coveralls.submit(process_folder())"
+       - C:\julia\bin\julia -e "using Pkg; Pkg.add(\"Coverage\"); using Coverage; Coveralls.submit(process_folder())"
        ```
 
 ## A note for advanced users


### PR DESCRIPTION
it seems the path to Julia has changed in Appveyor, to ```C:\julia\bin\julia```, so the readme should be adapted accordingly.

Closes #339
Closes #328