### PR TITLE
Add Gitlab CI to Coverage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Coverage"
 uuid = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 authors = ["Iain Dunning <iaindunning@gmail.com>", "contributors"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 CoverageTools = "c36e975a-824b-4404-a568-ef97ca766997"

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -187,7 +187,7 @@ function add_ci_to_kwargs(kwargs::Dict)
             job          = ENV["CI_JOB_ID"],
             build_url    = ENV["CI_PIPELINE_URL"],
             build        = ENV["CI_PIPELINE_IID"],
-            pr = num_mr,
+            pr           = num_mr,
         )
     else
         error("No compatible CI platform detected")

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -175,6 +175,15 @@ function add_ci_to_kwargs(kwargs::Dict)
         if ENV["BUILDKITE_PULL_REQUEST"] != "false"
             kwargs = set_defaults(kwargs, pr = ENV["BUILDKITE_PULL_REQUEST"])
         end
+    elseif haskey(ENV, "GITLAB_CI") 
+        kwargs = set_defaults(kwargs,
+            service      = "gitlab",
+            branch       = ENV["CI_COMMIT_REF_NAME"],
+            commit       = ENV["CI_COMMIT_SHA"],
+            job          = ENV["CI_JOB_ID"],
+            build        = ENV["CI_JOB_NAME"],
+            build_url    = ENV["CI_REPOSITORY_URL"]
+        )
     else
         error("No compatible CI platform detected")
     end

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -178,14 +178,16 @@ function add_ci_to_kwargs(kwargs::Dict)
         end
     elseif haskey(ENV, "GITLAB_CI")
         # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+        branch = ENV["CI_COMMIT_BRANCH"]
+        num_mr = branch == ENV["CI_DEFAULT_BRANCH"] ? "false" : ENV["CI_MERGE_REQUEST_IID"]
         kwargs = set_defaults(kwargs,
             service      = "gitlab",
-            branch       = ENV["CI_COMMIT_BRANCH"],
+            branch       = branch,
             commit       = ENV["CI_COMMIT_SHA"],
             job          = ENV["CI_JOB_ID"],
             build_url    = ENV["CI_PIPELINE_URL"],
             build        = ENV["CI_PIPELINE_IID"],
-            pull_request = ENV["CI_MERGE_REQUEST_TITLE"],
+            pull_request = num_mr,
         )
     else
         error("No compatible CI platform detected")

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -71,6 +71,7 @@ end
 
 add_ci_to_kwargs(; kwargs...) = add_ci_to_kwargs(Dict{Symbol,Any}(kwargs))
 function add_ci_to_kwargs(kwargs::Dict)
+    # https://docs.codecov.com/reference/upload
     if lowercase(get(ENV, "APPVEYOR", "false")) == "true"
         appveyor_pr = get(ENV, "APPVEYOR_PULL_REQUEST_NUMBER", "")
         appveyor_job = join(
@@ -175,13 +176,16 @@ function add_ci_to_kwargs(kwargs::Dict)
         if ENV["BUILDKITE_PULL_REQUEST"] != "false"
             kwargs = set_defaults(kwargs, pr = ENV["BUILDKITE_PULL_REQUEST"])
         end
-    elseif haskey(ENV, "GITLAB_CI") 
+    elseif haskey(ENV, "GITLAB_CI")
+        # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         kwargs = set_defaults(kwargs,
             service      = "gitlab",
-            branch       = ENV["CI_COMMIT_REF_NAME"],
+            branch       = ENV["CI_COMMIT_BRANCH"],
             commit       = ENV["CI_COMMIT_SHA"],
             job          = ENV["CI_JOB_ID"],
-            build_url    = ENV["CI_REPOSITORY_URL"]
+            build_url    = ENV["CI_PIPELINE_URL"],
+            build        = ENV["CI_PIPELINE_IID"],
+            pull_request = ENV["CI_MERGE_REQUEST_TITLE"],
         )
     else
         error("No compatible CI platform detected")

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -176,7 +176,7 @@ function add_ci_to_kwargs(kwargs::Dict)
         if ENV["BUILDKITE_PULL_REQUEST"] != "false"
             kwargs = set_defaults(kwargs, pr = ENV["BUILDKITE_PULL_REQUEST"])
         end
-    elseif haskey(ENV, "GITLAB_CI")
+    elseif lowercase(get(ENV, "GITLAB_CI", "false")) == "true"
         # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         branch = ENV["CI_COMMIT_REF_NAME"]
         num_mr = branch == ENV["CI_DEFAULT_BRANCH"] ? "false" : ENV["CI_MERGE_REQUEST_IID"]

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -178,7 +178,7 @@ function add_ci_to_kwargs(kwargs::Dict)
         end
     elseif haskey(ENV, "GITLAB_CI")
         # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-        branch = ENV["CI_COMMIT_BRANCH"]
+        branch = ENV["CI_COMMIT_REF_NAME"]
         num_mr = branch == ENV["CI_DEFAULT_BRANCH"] ? "false" : ENV["CI_MERGE_REQUEST_IID"]
         kwargs = set_defaults(kwargs,
             service      = "gitlab",
@@ -187,7 +187,7 @@ function add_ci_to_kwargs(kwargs::Dict)
             job          = ENV["CI_JOB_ID"],
             build_url    = ENV["CI_PIPELINE_URL"],
             build        = ENV["CI_PIPELINE_IID"],
-            pull_request = num_mr,
+            pr = num_mr,
         )
     else
         error("No compatible CI platform detected")

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -181,7 +181,6 @@ function add_ci_to_kwargs(kwargs::Dict)
             branch       = ENV["CI_COMMIT_REF_NAME"],
             commit       = ENV["CI_COMMIT_SHA"],
             job          = ENV["CI_JOB_ID"],
-            build        = ENV["CI_JOB_NAME"],
             build_url    = ENV["CI_REPOSITORY_URL"]
         )
     else

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -69,7 +69,7 @@ end
 
 function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=query_git_info)
     data = Dict{String,Any}("source_files" => map(to_json, fcs))
-
+    # Coveralls API : https://docs.coveralls.io/api-reference
     if local_env
         # Attempt to parse git info via git_info, unless the user explicitly disables it by setting git_info to nothing
         data["service_name"] = "local"
@@ -106,9 +106,12 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         github_pr::Union{AbstractString, Integer}
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
     elseif haskey(ENV, "GITLAB_CI")
+        # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+        data["service_number"] = ENV["CI_PIPELINE_IID"]
         data["service_job_id"] = ENV["CI_JOB_ID"]
         data["service_name"] = "gitlab"
         data["git"] = parse_git_info(git_info)
+        data["git"]["branch"] = ENV["CI_COMMIT_BRANCH"]
     else
         data["git"] = parse_git_info(git_info)
     end

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -105,7 +105,7 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         github_pr = get(github_pr_info, "number", "")
         github_pr::Union{AbstractString, Integer}
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
-    elseif haskey(ENV, "GITLAB_CI")
+    elseif lowercase(get(ENV, "GITLAB_CI", "false")) == "true"
         # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         branch = ENV["CI_COMMIT_REF_NAME"]
         num_mr = branch == ENV["CI_DEFAULT_BRANCH"] ? "false" : ENV["CI_MERGE_REQUEST_IID"]

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -107,7 +107,7 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
     elseif haskey(ENV, "GITLAB_CI")
         # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
-        branch = ENV["CI_COMMIT_BRANCH"]
+        branch = ENV["CI_COMMIT_REF_NAME"]
         num_mr = branch == ENV["CI_DEFAULT_BRANCH"] ? "false" : ENV["CI_MERGE_REQUEST_IID"]
         data["service_pull_request"] = num_mr
         data["service_number"] = ENV["CI_PIPELINE_IID"]

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -105,6 +105,10 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         github_pr = get(github_pr_info, "number", "")
         github_pr::Union{AbstractString, Integer}
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
+    elseif haskey(ENV, "GITLAB_CI")
+        data["service_job_id"] = ENV["CI_JOB_ID"]
+        data["service_name"] = "gitlab"
+        data["git"] = parse_git_info(git_info)
     else
         data["git"] = parse_git_info(git_info)
     end

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -106,7 +106,7 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         github_pr::Union{AbstractString, Integer}
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
     elseif haskey(ENV, "GITLAB_CI")
-        data["service_job_id"] = ENV["CI_JOB_ID"]
+#         data["service_job_id"] = ENV["CI_JOB_ID"]
         data["service_name"] = "gitlab"
         data["git"] = parse_git_info(git_info)
     else

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -106,7 +106,7 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         github_pr::Union{AbstractString, Integer}
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
     elseif haskey(ENV, "GITLAB_CI")
-#         data["service_job_id"] = ENV["CI_JOB_ID"]
+        data["service_job_id"] = ENV["CI_JOB_ID"]
         data["service_name"] = "gitlab"
         data["git"] = parse_git_info(git_info)
     else

--- a/src/coveralls.jl
+++ b/src/coveralls.jl
@@ -107,11 +107,14 @@ function prepare_request(fcs::Vector{FileCoverage}, local_env::Bool, git_info=qu
         ((github_pr isa Integer) || (!isempty(github_pr))) && (data["service_pull_request"] = strip(string(github_pr)))
     elseif haskey(ENV, "GITLAB_CI")
         # Gitlab API: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+        branch = ENV["CI_COMMIT_BRANCH"]
+        num_mr = branch == ENV["CI_DEFAULT_BRANCH"] ? "false" : ENV["CI_MERGE_REQUEST_IID"]
+        data["service_pull_request"] = num_mr
         data["service_number"] = ENV["CI_PIPELINE_IID"]
         data["service_job_id"] = ENV["CI_JOB_ID"]
         data["service_name"] = "gitlab"
         data["git"] = parse_git_info(git_info)
-        data["git"]["branch"] = ENV["CI_COMMIT_BRANCH"]
+        data["git"]["branch"] = branch
     else
         data["git"] = parse_git_info(git_info)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -710,36 +710,6 @@ withenv(
                 end
         end
 
-        # test Travis
-        withenv("TRAVIS" => "true",
-                "TRAVIS_BUILD_NUMBER" => "my_job_num",
-                "TRAVIS_JOB_ID" => "my_job_id",
-                "TRAVIS_PULL_REQUEST" => "t_pr",
-                "COVERALLS_PARALLEL" => "true") do
-                request = Coverage.Coveralls.prepare_request(fcs, false)
-                @test request["repo_token"] == "token_name_1"
-                @test request["service_number"] == "my_job_num"
-                @test request["service_job_id"] == "my_job_id"
-                @test request["service_name"] == "travis-ci"
-                @test request["service_pull_request"] == "t_pr"
-                @test request["parallel"] == "true"
-        end
-
-        # test Travis
-        withenv("TRAVIS" => "true",
-                "TRAVIS_BUILD_NUMBER" => "my_job_num",
-                "TRAVIS_JOB_ID" => "my_job_id",
-                "TRAVIS_PULL_REQUEST" => "t_pr",
-                "COVERALLS_PARALLEL" => "true") do
-                request = Coverage.Coveralls.prepare_request(fcs, false)
-                @test request["repo_token"] == "token_name_1"
-                @test request["service_number"] == "my_job_num"
-                @test request["service_job_id"] == "my_job_id"
-                @test request["service_name"] == "travis-ci"
-                @test request["service_pull_request"] == "t_pr"
-                @test request["parallel"] == "true"
-        end
-
         # test Gitlab see https://docs.coveralls.io/api-reference
         withenv("GITLAB_CI" => "true",
                 "CI_PIPELINE_IID" => "my_job_num",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -489,7 +489,7 @@ withenv(
             "GITLAB_CI" => "true",
             "CI_MERGE_REQUEST_IID" => "t_pr",
             "CI_JOB_ID" => "t_proj",
-            "CI_COMMIT_BRANCH" => "t_branch",
+            "CI_COMMIT_REF_NAME" => "t_branch",
             "CI_COMMIT_SHA" => "t_commit",
             "CI_PROJECT_NAME" => "t_repo",
             "CI_PIPELINE_URL" => "t_url",
@@ -503,7 +503,7 @@ withenv(
             @test occursin("service=gitlab", codecov_url)
             @test occursin("branch=t_branch", codecov_url)
             @test occursin("commit=t_commit", codecov_url)
-            @test occursin("pull_request=t_pr", codecov_url)
+            @test occursin("pr=t_pr", codecov_url)
             @test occursin("build_url=t_url", codecov_url)
             @test occursin("build=t_num", codecov_url)
 
@@ -515,7 +515,7 @@ withenv(
                 @test occursin("service=gitlab", codecov_url)
                 @test occursin("branch=t_branch", codecov_url)
                 @test occursin("commit=t_commit", codecov_url)
-                @test occursin("pull_request=t_pr", codecov_url)
+                @test occursin("pr=t_pr", codecov_url)
                 @test occursin("build_url=t_url", codecov_url)
                 @test occursin("build=t_num", codecov_url)
 
@@ -525,7 +525,7 @@ withenv(
                 @test occursin("service=gitlab", codecov_url)
                 @test occursin("branch=t_branch", codecov_url)
                 @test occursin("commit=t_commit", codecov_url)
-                @test occursin("pull_request=t_pr", codecov_url)
+                @test occursin("pr=t_pr", codecov_url)
                 @test occursin("build_url=t_url", codecov_url)
                 @test occursin("build=t_num", codecov_url)
 
@@ -538,7 +538,7 @@ withenv(
                     @test occursin("service=gitlab", codecov_url)
                     @test occursin("branch=t_branch", codecov_url)
                     @test occursin("commit=t_commit", codecov_url)
-                    @test occursin("pull_request=t_pr", codecov_url)
+                    @test occursin("pr=t_pr", codecov_url)
                     @test occursin("build_url=t_url", codecov_url)
                     @test occursin("build=t_num", codecov_url)
 
@@ -548,7 +548,7 @@ withenv(
                     @test occursin("service=gitlab", codecov_url)
                     @test occursin("branch=t_branch", codecov_url)
                     @test occursin("commit=t_commit", codecov_url)
-                    @test occursin("pull_request=t_pr", codecov_url)
+                    @test occursin("pr=t_pr", codecov_url)
                     @test occursin("build_url=t_url", codecov_url)
                     @test occursin("build=t_num", codecov_url)
                 end
@@ -714,7 +714,7 @@ withenv(
         withenv("GITLAB_CI" => "true",
                 "CI_PIPELINE_IID" => "my_job_num",
                 "CI_JOB_ID" => "my_job_id",
-                "CI_COMMIT_BRANCH" => "test",
+                "CI_COMMIT_REF_NAME" => "test",
                 "CI_DEFAULT_BRANCH" => "master",
                 "CI_MERGE_REQUEST_IID" => "t_pr") do
                 request = Coverage.Coveralls.prepare_request(fcs, false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -485,18 +485,16 @@ withenv(
         # test Gitlab ci submission process
 
         # set up Gitlab ci env
-                # test circle ci submission process
-
-        # set up circle ci env
         withenv(
             "GITLAB_CI" => "true",
-            "CI_MERGE_REQUEST_TITLE" => "t_pr",
+            "CI_MERGE_REQUEST_IID" => "t_pr",
             "CI_JOB_ID" => "t_proj",
-            "CI_COMMIT_REF_NAME" => "t_branch",
+            "CI_COMMIT_BRANCH" => "t_branch",
             "CI_COMMIT_SHA" => "t_commit",
             "CI_PROJECT_NAME" => "t_repo",
-            "CI_REPOSITORY_URL" => "t_url",
-            "CI_MERGE_REQUEST_ID" => "t_num",
+            "CI_PIPELINE_URL" => "t_url",
+            "CI_PIPELINE_IID" => "t_num",
+            "CI_DEFAULT_BRANCH" => "master",
             ) do
 
             # default values
@@ -745,14 +743,16 @@ withenv(
         # test Gitlab see https://docs.coveralls.io/api-reference
         withenv("GITLAB_CI" => "true",
                 "CI_PIPELINE_IID" => "my_job_num",
-                "CI_JOB_ID" => "my_job_id",) do
+                "CI_JOB_ID" => "my_job_id",
+                "CI_COMMIT_BRANCH" => "test",
+                "CI_DEFAULT_BRANCH" => "master",
+                "CI_MERGE_REQUEST_IID" => "t_pr") do
                 request = Coverage.Coveralls.prepare_request(fcs, false)
                 @test request["repo_token"] == "token_name_1"
                 @test request["service_number"] == "my_job_num"
                 @test request["service_job_id"] == "my_job_id"
                 @test request["service_name"] == "gitlab"
                 @test request["service_pull_request"] == "t_pr"
-                @test request["parallel"] == "true"
         end
 
         # test git_info (only works with Jenkins & local at the moment)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -482,6 +482,81 @@ withenv(
             end
         end
 
+        # test Gitlab ci submission process
+
+        # set up Gitlab ci env
+                # test circle ci submission process
+
+        # set up circle ci env
+        withenv(
+            "GITLAB_CI" => "true",
+            "CI_MERGE_REQUEST_TITLE" => "t_pr",
+            "CI_JOB_ID" => "t_proj",
+            "CI_COMMIT_REF_NAME" => "t_branch",
+            "CI_COMMIT_SHA" => "t_commit",
+            "CI_PROJECT_NAME" => "t_repo",
+            "CI_REPOSITORY_URL" => "t_url",
+            "CI_MERGE_REQUEST_ID" => "t_num",
+            ) do
+
+            # default values
+            codecov_url = construct_uri_string_ci()
+            @test occursin("codecov.io", codecov_url)
+            @test occursin("service=gitlab", codecov_url)
+            @test occursin("branch=t_branch", codecov_url)
+            @test occursin("commit=t_commit", codecov_url)
+            @test occursin("pull_request=t_pr", codecov_url)
+            @test occursin("build_url=t_url", codecov_url)
+            @test occursin("build=t_num", codecov_url)
+
+            # env var url override
+            withenv( "CODECOV_URL" => "https://enterprise-codecov-1.com" ) do
+
+                codecov_url = construct_uri_string_ci()
+                @test occursin("enterprise-codecov-1.com", codecov_url)
+                @test occursin("service=gitlab", codecov_url)
+                @test occursin("branch=t_branch", codecov_url)
+                @test occursin("commit=t_commit", codecov_url)
+                @test occursin("pull_request=t_pr", codecov_url)
+                @test occursin("build_url=t_url", codecov_url)
+                @test occursin("build=t_num", codecov_url)
+
+                # function argument url override
+                codecov_url = construct_uri_string_ci(codecov_url="https://enterprise-codecov-2.com")
+                @test occursin("enterprise-codecov-2.com", codecov_url)
+                @test occursin("service=gitlab", codecov_url)
+                @test occursin("branch=t_branch", codecov_url)
+                @test occursin("commit=t_commit", codecov_url)
+                @test occursin("pull_request=t_pr", codecov_url)
+                @test occursin("build_url=t_url", codecov_url)
+                @test occursin("build=t_num", codecov_url)
+
+                # env var token
+                withenv( "CODECOV_TOKEN" => "token_name_1" ) do
+
+                    codecov_url = construct_uri_string_ci()
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("token=token_name_1", codecov_url)
+                    @test occursin("service=gitlab", codecov_url)
+                    @test occursin("branch=t_branch", codecov_url)
+                    @test occursin("commit=t_commit", codecov_url)
+                    @test occursin("pull_request=t_pr", codecov_url)
+                    @test occursin("build_url=t_url", codecov_url)
+                    @test occursin("build=t_num", codecov_url)
+
+                    # function argument token url override
+                    codecov_url = construct_uri_string_ci(token="token_name_2")
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("service=gitlab", codecov_url)
+                    @test occursin("branch=t_branch", codecov_url)
+                    @test occursin("commit=t_commit", codecov_url)
+                    @test occursin("pull_request=t_pr", codecov_url)
+                    @test occursin("build_url=t_url", codecov_url)
+                    @test occursin("build=t_num", codecov_url)
+                end
+            end
+        end
+
         # test codecov token masking
         withenv(
             "APPVEYOR" => "true",
@@ -635,6 +710,49 @@ withenv(
                         @test request["service_job_number"] == "ci_job_num"
                         @test request["service_job_id"] == "ci_job_id"
                 end
+        end
+
+        # test Travis
+        withenv("TRAVIS" => "true",
+                "TRAVIS_BUILD_NUMBER" => "my_job_num",
+                "TRAVIS_JOB_ID" => "my_job_id",
+                "TRAVIS_PULL_REQUEST" => "t_pr",
+                "COVERALLS_PARALLEL" => "true") do
+                request = Coverage.Coveralls.prepare_request(fcs, false)
+                @test request["repo_token"] == "token_name_1"
+                @test request["service_number"] == "my_job_num"
+                @test request["service_job_id"] == "my_job_id"
+                @test request["service_name"] == "travis-ci"
+                @test request["service_pull_request"] == "t_pr"
+                @test request["parallel"] == "true"
+        end
+
+        # test Travis
+        withenv("TRAVIS" => "true",
+                "TRAVIS_BUILD_NUMBER" => "my_job_num",
+                "TRAVIS_JOB_ID" => "my_job_id",
+                "TRAVIS_PULL_REQUEST" => "t_pr",
+                "COVERALLS_PARALLEL" => "true") do
+                request = Coverage.Coveralls.prepare_request(fcs, false)
+                @test request["repo_token"] == "token_name_1"
+                @test request["service_number"] == "my_job_num"
+                @test request["service_job_id"] == "my_job_id"
+                @test request["service_name"] == "travis-ci"
+                @test request["service_pull_request"] == "t_pr"
+                @test request["parallel"] == "true"
+        end
+
+        # test Gitlab see https://docs.coveralls.io/api-reference
+        withenv("GITLAB_CI" => "true",
+                "CI_PIPELINE_IID" => "my_job_num",
+                "CI_JOB_ID" => "my_job_id",) do
+                request = Coverage.Coveralls.prepare_request(fcs, false)
+                @test request["repo_token"] == "token_name_1"
+                @test request["service_number"] == "my_job_num"
+                @test request["service_job_id"] == "my_job_id"
+                @test request["service_name"] == "gitlab"
+                @test request["service_pull_request"] == "t_pr"
+                @test request["parallel"] == "true"
         end
 
         # test git_info (only works with Jenkins & local at the moment)


### PR DESCRIPTION
This allows to directly submit the Coverage report to Codecov or Coveralls from a Gitlab action.
This solves #330 