### PR TITLE
Allow Codecov submission from Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,27 @@
+freebsd_instance:
+  image: freebsd-12-2-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.6
+      - JULIA_VERSION: 1
+      - JULIA_VERSION: nightly
+  allow_failures: $JULIA_VERSION == 'nightly'
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - |
+        export JULIA_COVERAGE_BLACK_HOLE_SERVER_URL_PUT="https://httpbingo.julialang.org/put"
+        cirrusjl test
+    - |
+        export JULIA_COVERAGE_IS_BLACK_HOLE_SERVER="true"
+        export COVERALLS_TOKEN="token"
+        export COVERALLS_URL="https://httpbingo.julialang.org/post"
+        export CODECOV_URL="https://httpbingo.julialang.org"
+        export CODECOV_URL_PATH="/post"
+        julia --color=yes --project=. --code-coverage=user etc/travis-coverage.jl
+  coverage_script:
+    - julia --color=yes --project=. etc/travis-coverage.jl

--- a/etc/travis-coverage.jl
+++ b/etc/travis-coverage.jl
@@ -1,4 +1,8 @@
 using Coverage
 cov_res = process_folder()
 Codecov.submit(cov_res)
-Coveralls.submit(cov_res)
+if Sys.isfreebsd()
+    @warn "Skipping Coveralls on FreeBSD"
+else
+    Coveralls.submit(cov_res)
+end

--- a/src/codecovio.jl
+++ b/src/codecovio.jl
@@ -189,6 +189,15 @@ function add_ci_to_kwargs(kwargs::Dict)
             build        = ENV["CI_PIPELINE_IID"],
             pr           = num_mr,
         )
+    elseif lowercase(get(ENV, "CIRRUS_CI", "false")) == "true"
+        kwargs = set_defaults(kwargs,
+            service      = "cirrus",
+            branch       = ENV["CIRRUS_BRANCH"],
+            commit       = ENV["CIRRUS_CHANGE_IN_REPO"],
+            pull_request = get(ENV, "CIRRUS_PR", "false"),
+            slug         = ENV["CIRRUS_REPO_FULL_NAME"],
+            build        = ENV["CIRRUS_BUILD_ID"],
+        )
     else
         error("No compatible CI platform detected")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ withenv(
     "JENKINS" => nothing,
     "BUILD_ID" => nothing,
     "CI_PULL_REQUEST" => nothing,
-    "GIT_BRANCH" => nothing
+    "GIT_BRANCH" => nothing,
     "CIRRUS_CI" => nothing,
     "CIRRUS_PR" => nothing,
     "CIRRUS_BRANCH" => nothing,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,12 @@ withenv(
     "BUILD_ID" => nothing,
     "CI_PULL_REQUEST" => nothing,
     "GIT_BRANCH" => nothing
+    "CIRRUS_CI" => nothing,
+    "CIRRUS_PR" => nothing,
+    "CIRRUS_BRANCH" => nothing,
+    "CIRRUS_CHANGE_IN_REPO" => nothing,
+    "CIRRUS_REPO_FULL_NAME" => nothing,
+    "CIRRUS_BUILD_ID" => nothing,
     ) do
 
     @testset "codecovio.jl" begin
@@ -550,6 +556,66 @@ withenv(
                     @test occursin("commit=t_commit", codecov_url)
                     @test occursin("pr=t_pr", codecov_url)
                     @test occursin("build_url=t_url", codecov_url)
+                    @test occursin("build=t_num", codecov_url)
+                end
+            end
+        end
+
+        # Test Cirrus CI submission process
+
+        # Set up Cirrus CI environment
+        withenv("CIRRUS_CI" => "true",
+                "CIRRUS_PR" => "t_pr",
+                "CIRRUS_BRANCH" => "t_branch",
+                "CIRRUS_CHANGE_IN_REPO" => "t_commit",
+                "CIRRUS_REPO_FULL_NAME" => "t_repo",
+                "CIRRUS_BUILD_ID" => "t_num") do
+            # default values
+            codecov_url = construct_uri_string_ci()
+            @test occursin("codecov.io", codecov_url)
+            @test occursin("service=cirrus", codecov_url)
+            @test occursin("branch=t_branch", codecov_url)
+            @test occursin("commit=t_commit", codecov_url)
+            @test occursin("pull_request=t_pr", codecov_url)
+            @test occursin("build=t_num", codecov_url)
+
+            # env var url override
+            withenv("CODECOV_URL" => "https://enterprise-codecov-1.com") do
+                codecov_url = construct_uri_string_ci()
+                @test occursin("enterprise-codecov-1.com", codecov_url)
+                @test occursin("service=cirrus", codecov_url)
+                @test occursin("branch=t_branch", codecov_url)
+                @test occursin("commit=t_commit", codecov_url)
+                @test occursin("pull_request=t_pr", codecov_url)
+                @test occursin("build=t_num", codecov_url)
+
+                # function argument url override
+                codecov_url = construct_uri_string_ci(codecov_url="https://enterprise-codecov-2.com")
+                @test occursin("enterprise-codecov-2.com", codecov_url)
+                @test occursin("service=cirrus", codecov_url)
+                @test occursin("branch=t_branch", codecov_url)
+                @test occursin("commit=t_commit", codecov_url)
+                @test occursin("pull_request=t_pr", codecov_url)
+                @test occursin("build=t_num", codecov_url)
+
+                # env var token
+                withenv("CODECOV_TOKEN" => "token_name_1") do
+                    codecov_url = construct_uri_string_ci()
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("token=token_name_1", codecov_url)
+                    @test occursin("service=cirrus", codecov_url)
+                    @test occursin("branch=t_branch", codecov_url)
+                    @test occursin("commit=t_commit", codecov_url)
+                    @test occursin("pull_request=t_pr", codecov_url)
+                    @test occursin("build=t_num", codecov_url)
+
+                    # function argument token url override
+                    codecov_url = construct_uri_string_ci(token="token_name_2")
+                    @test occursin("enterprise-codecov-1.com", codecov_url)
+                    @test occursin("service=cirrus", codecov_url)
+                    @test occursin("branch=t_branch", codecov_url)
+                    @test occursin("commit=t_commit", codecov_url)
+                    @test occursin("pull_request=t_pr", codecov_url)
                     @test occursin("build=t_num", codecov_url)
                 end
             end


### PR DESCRIPTION
Picking up from #192, as Cirrus seems now to be better supported by Codecov itself (e.g. https://community.codecov.com/t/add-support-of-uploading-from-cirrus-ci-without-token/1028/34). No idea whether it'll work now but worth another try.