### PR TITLE
updated README to update the after test path to julia bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ When using Coverage.jl locally, over time a lot of `.cov` files can accumulate. 
 
        ```yml
        after_test:
-       - C:\projects\julia\bin\julia -e "using Pkg; Pkg.add(\"Coverage\"); using Coverage; Coveralls.submit(process_folder())"
+       - C:\julia\bin\julia -e "using Pkg; Pkg.add(\"Coverage\"); using Coverage; Coveralls.submit(process_folder())"
        ```
 
 ## A note for advanced users


### PR DESCRIPTION
The previous path for the bin folder was giving an error when building. So the documentation now contains the updated path which is compactible.