### PR TITLE
Update README.md with Tidier.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ For AppVeyor, add this to `.appveyor.yml`:
 * [TaylorIntegration.jl](https://github.com/PerezHz/TaylorIntegration.jl)
 * [TaylorSeries.jl](https://github.com/JuliaDiff/TaylorSeries.jl)
 * [TextWrap.jl](https://github.com/carlobaldassi/TextWrap.jl)
+* [Tidier.jl](https://github.com/TidierOrg/Tidier.jl)
 * [TimeData.jl](https://github.com/cgroll/TimeData.jl)
 * [TypeCheck.jl](https://github.com/astrieanna/TypeCheck.jl)
 * [Unitful.jl](https://github.com/ajkeller34/Unitful.jl)


### PR DESCRIPTION
Adds Tidier.jl to list of packages using Coverage.jl. Currently, we are actively uploading coverage to coveralls.io on TidierPlots.jl and TidierDB.jl, but we may expand to the rest of the Tidier subpackages soon. 