### PR TITLE
ci: use `macos-15-intel`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
             os: macos-latest
             arch: aarch64
           - version: '1'
-            os: macos-13
+            os: macos-15-intel
             arch: x64
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
> The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead.
