### PR TITLE
Fix Coveralls parallel completion webhook

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Coverage"
 uuid = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
-version = "1.8.1"
+version = "1.8.2"
 authors = ["Iain Dunning <iaindunning@gmail.com>", "contributors"]
 
 [deps]

--- a/src/ci_integration_functions.jl
+++ b/src/ci_integration_functions.jl
@@ -313,6 +313,10 @@ This should be called once after all parallel upload_to_coveralls() calls are co
 - `token`: Coveralls repo token (defaults to COVERALLS_REPO_TOKEN environment variable)
 - `build_num`: Build number for the parallel jobs (overrides COVERALLS_SERVICE_NUMBER environment variable)
 
+The Coveralls host defaults to `https://coveralls.io` and can be overridden with
+the `COVERALLS_ENDPOINT` environment variable. An unsuccessful response raises an
+error so callers can retry the request.
+
 Call this from a separate CI job that runs after all parallel coverage jobs finish.
 """
 function finish_coveralls_parallel(; token=nothing, build_num=nothing)
@@ -321,9 +325,10 @@ function finish_coveralls_parallel(; token=nothing, build_num=nothing)
     if upload_token === nothing
         upload_token = get(ENV, "COVERALLS_REPO_TOKEN", nothing)
     end
-    if upload_token === nothing
+    if upload_token === nothing || upload_token == ""
         error("Coveralls token required for parallel completion. Set COVERALLS_REPO_TOKEN environment variable or pass token parameter.")
     end
+    upload_token = string(upload_token)
 
     # Prepare the completion webhook payload
     payload_data = Dict("status" => "done")
@@ -337,29 +342,48 @@ function finish_coveralls_parallel(; token=nothing, build_num=nothing)
         @warn "No build number available for parallel completion - this may cause issues with parallel job grouping"
     end
 
-    payload = Dict(
-        "repo_token" => upload_token,
-        "payload" => payload_data
+    payload = Dict("payload" => payload_data)
+    endpoint = get(ENV, "COVERALLS_ENDPOINT", "")
+    isempty(endpoint) && (endpoint = "https://coveralls.io")
+    webhook_url = "$(rstrip(endpoint, '/'))/webhook"
+    # HTTP errors can include the token-bearing request URL; keep it out of CI logs.
+    scrub_token(message) = replace(
+        replace(message, r"repo_token=[^&\s\"']*" => "repo_token=<redacted>"),
+        upload_token => "<redacted>",
     )
 
     @info "Signaling Coveralls parallel job completion..."
 
-    try
-        response = HTTP.post(
-            "https://coveralls.io/webhook",
+    response = try
+        HTTP.post(
+            webhook_url,
             ["Content-Type" => "application/json"],
-            JSON.json(payload)
+            JSON.json(payload);
+            query=Dict("repo_token" => upload_token),
+            status_exception=false,
         )
-
-        if response.status == 200
-            @info "Successfully signaled parallel job completion to Coveralls"
-            return true
-        else
-            @error "Failed to signal parallel completion" status=response.status
-            return false
-        end
-    catch e
-        @error "Error signaling parallel completion to Coveralls" exception=e
-        return false
+    catch err
+        error("Coveralls parallel completion request failed: " *
+              scrub_token(sprint(showerror, err)))
     end
+
+    response_body = scrub_token(String(response.body))
+    response_data = try
+        JSON.parse(response_body)
+    catch
+        nothing
+    end
+
+    if !(200 <= response.status < 300)
+        message = response_data isa AbstractDict ? get(response_data, "error", response_body) : response_body
+        error("Coveralls parallel completion failed (HTTP $(response.status)): $message")
+    elseif !(response_data isa AbstractDict)
+        error("Coveralls parallel completion returned invalid JSON (HTTP $(response.status)): $response_body")
+    elseif get(response_data, "done", false) !== true
+        message = get(response_data, "error", response_body)
+        error("Coveralls did not complete the parallel build: $message")
+    end
+
+    @info "Successfully completed Coveralls parallel build" url=get(response_data, "url", nothing) jobs=get(response_data, "jobs", nothing)
+    return true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 # https://github.com/JuliaCI/Coverage.jl
 #######################################################################
 
-using Coverage, Test, LibGit2, JSON
+using Coverage, Test, LibGit2, JSON, HTTP
 
 import CoverageTools
 
@@ -14,6 +14,7 @@ withenv(
     "DISABLE_AMEND_COVERAGE_FROM_SRC" => nothing,
     "COVERALLS_TOKEN" => "token_name_1",
     "COVERALLS_URL" => nothing,
+    "COVERALLS_ENDPOINT" => nothing,
     "CODECOV_URL" => nothing,
     "CODECOV_URL_PATH" => nothing,
     "CODECOV_TOKEN" => nothing,
@@ -1133,7 +1134,65 @@ withenv(
                 @test success == true
 
                 # Test finish_coveralls_parallel requires token
-                @test_throws ErrorException Coverage.finish_coveralls_parallel()
+                withenv("COVERALLS_REPO_TOKEN" => nothing) do
+                    @test_throws ErrorException Coverage.finish_coveralls_parallel()
+                end
+
+                if isdefined(HTTP, :serve!) && isdefined(HTTP, :port)
+                    requests = HTTP.Request[]
+                    responses = HTTP.Response[
+                        HTTP.Response(200, JSON.json(Dict(
+                            "done" => true,
+                            "url" => "https://coveralls.io/builds/123",
+                            "jobs" => 3,
+                        ))),
+                        HTTP.Response(422, JSON.json(Dict("error" => "No matching build"))),
+                        HTTP.Response(200, JSON.json(Dict("done" => false))),
+                        HTTP.Response(200, "not json"),
+                    ]
+                    server = HTTP.serve!("127.0.0.1", 0; listenany=true) do request
+                        push!(requests, request)
+                        return isempty(responses) ? HTTP.Response(599, "unexpected request") :
+                               popfirst!(responses)
+                    end
+                    port = HTTP.port(server)
+
+                    try
+                        withenv("COVERALLS_ENDPOINT" => "http://127.0.0.1:$port") do
+                            @test Coverage.finish_coveralls_parallel(
+                                token="token with & symbols", build_num=123)
+                            @test_throws ErrorException Coverage.finish_coveralls_parallel(
+                                token="token", build_num=123)
+                            @test_throws ErrorException Coverage.finish_coveralls_parallel(
+                                token="token", build_num=123)
+                            @test_throws ErrorException Coverage.finish_coveralls_parallel(
+                                token="token", build_num=123)
+                        end
+                    finally
+                        close(server)
+                    end
+
+                    @test length(requests) == 4
+                    @test isempty(responses)
+                    request = first(requests)
+                    @test request.target ==
+                        "/webhook?repo_token=token%20with%20%26%20symbols"
+                    @test HTTP.header(request, "Content-Type") == "application/json"
+                    @test JSON.parse(request.body) == Dict(
+                        "payload" => Dict("build_num" => "123", "status" => "done"))
+
+                    secret = "secret token&value"
+                    err = withenv("COVERALLS_ENDPOINT" => "http://127.0.0.1:$port") do
+                        try
+                            Coverage.finish_coveralls_parallel(token=secret, build_num=123)
+                        catch err
+                            err
+                        end
+                    end
+                    @test err isa ErrorException
+                    @test !occursin(secret, sprint(showerror, err))
+                    @test !occursin("secret%20token%26value", sprint(showerror, err))
+                end
 
                 # Test process_and_upload with parallel options
                 mkdir("src")


### PR DESCRIPTION
Pass the repository token as an encoded query parameter, validate Coveralls' JSON response, and raise completion failures so CI retry wrappers can retry them. Honor COVERALLS_ENDPOINT and cover success and failure responses with focused tests.

Without this, the Coveralls submissions are left on "pending completion" (as observed with the Julia scheduled coverage job).